### PR TITLE
Hotfix:#63

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/folder/FolderFragment.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/folder/FolderFragment.java
@@ -81,16 +81,16 @@ public class FolderFragment extends Fragment {
         recyclerView.setLayoutManager(gridLayoutManager);
 
         // @deprecated : add()
-        addItem(R.mipmap.ic_launcher, "name1", 32);
-        addItem(R.mipmap.ic_launcher, "name2", 1);
-        addItem(R.mipmap.ic_launcher, "name3", 5);
-        addItem(R.mipmap.ic_launcher, "name4", 2);
-        addItem(R.mipmap.ic_launcher, "name5", 124);
-        addItem(R.mipmap.ic_launcher, "name6", 5151);
-        addItem(R.mipmap.ic_launcher, "name7", 231);
-        addItem(R.mipmap.ic_launcher, "name8", 241);
-        addItem(R.mipmap.ic_launcher, "name9", 1);
-        addItem(R.mipmap.ic_launcher, "name10", 23);
+        addItem(R.drawable.sample, "name1", 32);
+        addItem(R.drawable.sample, "name2", 1);
+        addItem(R.drawable.sample, "name3", 5);
+        addItem(R.drawable.sample, "name4", 2);
+        addItem(R.drawable.sample, "name5", 124);
+        addItem(R.drawable.sample, "name6", 5151);
+        addItem(R.drawable.sample, "name7", 231);
+        addItem(R.drawable.sample, "name8", 241);
+        addItem(R.drawable.sample, "name9", 1);
+        addItem(R.drawable.sample, "name10", 23);
 
         adapter.notifyDataSetChanged();
     }

--- a/app/src/main/res/layout/folder_item.xml
+++ b/app/src/main/res/layout/folder_item.xml
@@ -4,15 +4,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginBottom="20dp">
+    android:layout_marginBottom="7.5dp">
 
     <!-- @brief : 폴더화면 아이템 리스트 중 아이템 하나의 뷰 -->
-    <ImageView
+    <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/folder_item"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_margin="7.5dp"
         android:scaleType="centerCrop"
-        android:src="@drawable/ic_launcher"
+        android:src="@drawable/sample"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -22,7 +23,8 @@
         android:id="@+id/folder_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="10dp"
+        android:layout_marginLeft="2dp"
+        android:layout_marginTop="15dp"
         android:fontFamily="@font/nanum_square_b"
         android:text="폴더명"
         android:textColor="@color/black"
@@ -47,10 +49,10 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="5dp"
-        android:layout_marginRight="10dp"
+        android:layout_marginRight="2dp"
         android:background="@android:color/transparent"
         android:src="@drawable/more"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintRight_toRightOf="@id/folder_item"
         app:layout_constraintTop_toTopOf="@id/folder_name"
         app:layout_constraintTop_toBottomOf="@id/folder_item"
         android:onClick="onClick" />

--- a/app/src/main/res/layout/folder_list_item.xml
+++ b/app/src/main/res/layout/folder_list_item.xml
@@ -2,35 +2,40 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="15dp">
-
-    <ImageView
+    android:layout_margin="15dp"
+    >
+    <de.hdodenhof.circleimageview.CircleImageView
         android:id="@+id/folder_image"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_launcher"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/sample"
         android:background="@android:color/transparent"/>
 
-    <TextView
-        android:id="@+id/folder_name"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:layout_marginLeft="15dp"
-        android:layout_gravity="center"
-        android:fontFamily="@font/nanum_square_r"
-        android:text="카테고리명"
-        android:textColor="@color/black"
-        android:textSize="15dp" />
+        android:layout_gravity="center_vertical"
+        android:gravity="center_vertical">
 
-    <RadioButton
-        android:id="@+id/checkbox"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_weight="0"
-        android:layout_marginTop="13dp"
-        android:onClick="onClick"
-        android:background="@drawable/unselect"
-        android:button="@android:color/transparent"
-        android:checked="false"/>
+        <TextView
+            android:id="@+id/folder_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:layout_marginLeft="15dp"
+            android:fontFamily="@font/nanum_square_r"
+            android:text="카테고리명"
+            android:textColor="@color/black"
+            android:textSize="15dp" />
+
+        <RadioButton
+            android:id="@+id/checkbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:onClick="onClick"
+            android:background="@drawable/unselect"
+            android:button="@android:color/transparent"
+            android:checked="false"/>
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -55,7 +55,7 @@
             android:id="@+id/recyclerview_folders_list"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:layout_marginTop="15dp"
+            android:layout_margin="7.5dp"
             android:scrollbarFadeDuration="0"
             android:scrollbarSize="5dp"
             android:scrollbarThumbVertical="@android:color/darker_gray"


### PR DESCRIPTION
폴더 관련 xml 수정합니다.
1. fragment_folder.xml에서 RecyclerView와 folder_item.xml에서 마진 15dp->7.5dp로 수정 (마진을 15dp로 줄 경우, 두 컬럼 사이의 마진이 30dp이 되므로 의도한 15dp를 유지하기 위해 각 뷰의 마진을 7.5dp로 설정함)
2. folder_item.xml과 folder_list_item.xml의 에서 이미지 뷰를 원형 이미지 뷰로 변경.
3. folder_item.xml에서 일부 정렬이 안 맞는 뷰의 마진을 수정
4. folder_list_item.xml에서 이미지만 보이는 문제를 레이아웃 변경, weight, margin 속성 수정 등을 통해 해결
5. FolderFragment.java에서 원형 이미지 뷰가 잘 보일 수 있도록 테스트용 이미지를 기본 아이콘에서 sample 이미지(일반 스마트폰 해상도 이미지)로 변경