### PR TITLE
Hotfix:#76

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,7 +32,7 @@
         <service
             android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
             android:enabled="true" />
-
+        <activity android:name=".detail.ItemDetailActivity" />
         <activity android:name=".cart.CartActivity" /> <!-- <activity android:name=".folder.FolderList"></activity> -->
         <activity android:name=".folder.FolderListActivity" />
         <activity android:name=".MainActivity">

--- a/app/src/main/java/com/hyeeyoung/wishboard/adapter/CartAdapter.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/adapter/CartAdapter.java
@@ -1,5 +1,6 @@
 package com.hyeeyoung.wishboard.adapter;
 
+import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,7 +42,7 @@ public class CartAdapter extends RecyclerView.Adapter<CartAdapter.CustomViewHold
     public CustomViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
 
         View view = LayoutInflater.from(viewGroup.getContext())
-                .inflate(R.layout.cart_ltem, viewGroup, false);
+                .inflate(R.layout.cart_item, viewGroup, false);
 
         CustomViewHolder viewHolder = new CustomViewHolder(view);
 
@@ -49,12 +50,12 @@ public class CartAdapter extends RecyclerView.Adapter<CartAdapter.CustomViewHold
     }
 
     @Override
-    public void onBindViewHolder(@NonNull CustomViewHolder viewholder, int position) {
+    public void onBindViewHolder(@NonNull CustomViewHolder holder, int position) {
         CartItem item = cartList.get(position);
-        viewholder.item_image.setImageResource(item.getItem_image());
-        viewholder.item_name.setText(item.getItem_name());
-        viewholder.total.setText(item.getTotal());
-        viewholder.quantity.setText(item.getQty()+"");
+        holder.item_image.setImageResource(item.getItem_image());
+        holder.item_name.setText(item.getItem_name());
+        holder.total.setText(item.getTotal());
+        holder.quantity.setText(item.getQty()+"");
     }
     @Override
     public int getItemCount() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/adapter/FolderAdapter.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/adapter/FolderAdapter.java
@@ -1,5 +1,6 @@
 package com.hyeeyoung.wishboard.adapter;
 
+import android.graphics.drawable.GradientDrawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -21,6 +22,7 @@ public class FolderAdapter extends RecyclerView.Adapter<FolderAdapter.CustomView
         protected ImageView folder_image;
         protected TextView folder_name;
         protected TextView item_count;
+
 
         public CustomViewHolder(View view) {
             super(view);

--- a/app/src/main/java/com/hyeeyoung/wishboard/adapter/ItemAdapter.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/adapter/ItemAdapter.java
@@ -1,29 +1,36 @@
 package com.hyeeyoung.wishboard.adapter;
 
+import android.content.Intent;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
+import android.widget.Toast;
+
 import androidx.annotation.NonNull;
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.RecyclerView;
 import com.hyeeyoung.wishboard.R;
+import com.hyeeyoung.wishboard.detail.ItemDetailActivity;
 import com.hyeeyoung.wishboard.model.WishItem;
 import java.util.ArrayList;
 
 public class ItemAdapter extends RecyclerView.Adapter<ItemAdapter.CustomViewHolder> {
     private ArrayList<WishItem> wishList;
+    private Intent intent;
 
     public class CustomViewHolder extends RecyclerView.ViewHolder {
         protected ImageView item_image;
         protected TextView item_name;
         protected TextView item_price;
-
+        protected ConstraintLayout item;
         public CustomViewHolder(View view) {
             super(view);
             this.item_image = (ImageView) view.findViewById(R.id.item_image);
             this.item_name = (TextView) view.findViewById(R.id.item_name);
             this.item_price = (TextView) view.findViewById(R.id.item_price);
+            this.item = (ConstraintLayout) view.findViewById(R.id.item);
         }
     }
     public ItemAdapter(ArrayList<WishItem> data) {
@@ -42,12 +49,21 @@ public class ItemAdapter extends RecyclerView.Adapter<ItemAdapter.CustomViewHold
     }
 
     @Override
-    public void onBindViewHolder(@NonNull CustomViewHolder viewholder, int position) {
+    public void onBindViewHolder(@NonNull CustomViewHolder viewholder, final int position) {
         WishItem item = wishList.get(position);
         // viewholder.item_image.setImageDrawable(item.getItem_image()); @ deprecated : 안드로이드 기본 아이콘 대신 실제 상품 이미지로 테스트 할 경우 주석 제거 후 사용
         viewholder.item_image.setImageResource(item.getItem_image());
         viewholder.item_name.setText(item.getItem_name());
         viewholder.item_price.setText(item.getItem_price());
+
+        // @param : 아이템 클릭 시 아이템 상세조회로 이동동
+       viewholder.item.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                intent = new Intent(v.getContext(), ItemDetailActivity.class);
+                v.getContext().startActivity(intent);
+            }
+        });
     }
     @Override
     public int getItemCount() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/add/LinkSharingActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/add/LinkSharingActivity.java
@@ -108,6 +108,7 @@ public class LinkSharingActivity extends AppCompatActivity {
         date.setDisplayedValues(dates); //@param : 디스플레이될 날짜 값 설정
         date.setDescendantFocusability(NumberPicker.FOCUS_BLOCK_DESCENDANTS);
 
+
         // @brief : 시간 설정, 0~23시 까지 넘버피커 설정
         hour.setMinValue(0); // @param : 범위의 최소값을 설정
         hour.setMaxValue(23); // @param : 범위의 최댓값을 설정

--- a/app/src/main/res/drawable/background_tag.xml
+++ b/app/src/main/res/drawable/background_tag.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="7dp"/>
+    <solid android:color="@color/pastelGreen"/>
+</shape>

--- a/app/src/main/res/drawable/button_green.xml
+++ b/app/src/main/res/drawable/button_green.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item>
-        <shape android:shape="rectangle">
-            <corners android:radius="100dp"/>
-            <solid android:color="@color/green"/>
-        </shape>
-    </item>
-</selector>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="25dp"/>
+    <solid android:color="@color/green"/>
+</shape>

--- a/app/src/main/res/layout/activity_cart.xml
+++ b/app/src/main/res/layout/activity_cart.xml
@@ -3,105 +3,125 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:orientation="vertical">
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp">
+        android:padding="15dp">
+
         <ImageButton
             android:id="@+id/back"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
             android:onClick="onClick"
-            android:src="@drawable/back"
-            android:background="@android:color/transparent" />
+            android:src="@drawable/back" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_centerHorizontal="true"
-            android:textSize="20dp"
-            android:textColor="@color/black"
             android:fontFamily="@font/noto_sans_kr_bold"
-            android:text="cart" />
+            android:text="cart"
+            android:textColor="@color/black"
+            android:textSize="20dp" />
+
+        <ImageButton
+            android:id="@+id/edit"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:layout_marginRight="2dp"
+            android:background="@android:color/transparent"
+            android:src="@drawable/edit" />
 
     </RelativeLayout>
-    <RelativeLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginHorizontal="15dp"
-        android:layout_marginBottom="15dp">
-        <!--@breif android:button="@null" : 커스텀 된 이미지가 체크박스의 크기에 맞게 들어간다.-->
-        <CheckBox
-            android:id="@+id/check_box"
-            android:layout_width="25dp"
-            android:layout_height="25dp"
-            android:button="@null"
-            android:checked="false"
-            android:background="@drawable/custom_checkbox" />
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_toRightOf="@id/check_box"
-            android:layout_marginLeft="5dp"
-            android:textSize="13dp"
-            android:textColor="@color/mediumGray"
-            android:fontFamily="@font/nanum_square_r"
-            android:text="전체선택" />
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_centerVertical="true"
-            android:layout_alignParentEnd="true"
-            android:layout_marginLeft="5dp"
-            android:textSize="13dp"
-            android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_b"
-            android:text="선택삭제" />
-    </RelativeLayout>
-    <View
-        android:layout_width="match_parent"
-        android:layout_height="0.5dp"
-        android:background="@color/black">
-    </View>
+
+<!--    <RelativeLayout-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="wrap_content"-->
+<!--        android:layout_marginBottom="10dp"-->
+<!--        android:paddingHorizontal="15dp">-->
+<!--        &lt;!&ndash;@breif android:button="@null" : 커스텀 된 이미지가 체크박스의 크기에 맞게 들어간다.&ndash;&gt;-->
+<!--        <CheckBox-->
+<!--            android:id="@+id/check_box"-->
+<!--            android:layout_width="20dp"-->
+<!--            android:layout_height="20dp"-->
+<!--            android:layout_centerVertical="true"-->
+<!--            android:background="@drawable/custom_checkbox"-->
+<!--            android:button="@null"-->
+<!--            android:checked="false" />-->
+
+<!--        <TextView-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_centerVertical="true"-->
+<!--            android:layout_marginLeft="5dp"-->
+<!--            android:layout_toRightOf="@id/check_box"-->
+<!--            android:fontFamily="@font/nanum_square_r"-->
+<!--            android:text="전체선택"-->
+<!--            android:textColor="@color/mediumGray"-->
+<!--            android:textSize="13dp" />-->
+
+<!--        <TextView-->
+<!--            android:layout_width="wrap_content"-->
+<!--            android:layout_height="wrap_content"-->
+<!--            android:layout_alignParentEnd="true"-->
+<!--            android:layout_centerVertical="true"-->
+<!--            android:layout_marginLeft="5dp"-->
+<!--            android:fontFamily="@font/nanum_square_b"-->
+<!--            android:text="선택삭제"-->
+<!--            android:textColor="@color/black"-->
+<!--            android:textSize="13dp" />-->
+<!--    </RelativeLayout>-->
+    <!--            <View-->
+    <!--                android:layout_width="match_parent"-->
+    <!--                android:layout_height="0.5dp"-->
+    <!--                android:background="@color/black" />-->
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview_cart_list"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"/>
+        android:layout_weight="1" />
+
     <RelativeLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:padding="15dp"
-        android:background="@color/green">
+        android:layout_height="50dp"
+        android:background="@color/green"
+        android:padding="15dp">
+
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textSize="17dp"
-            android:textColor="@color/black"
             android:fontFamily="@font/nanum_square_r"
-            android:text="TOTAL" />
+            android:text="TOTAL"
+            android:textColor="@color/black"
+            android:textSize="17dp" />
+
         <TextView
             android:id="@+id/total"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_toLeftOf="@id/won"
-            android:textSize="17dp"
-            android:textColor="@color/black"
             android:fontFamily="@font/nanum_square_eb"
-            android:text="238,000" />
+            android:text="238,000"
+            android:textColor="@color/black"
+            android:textSize="17dp" />
+
         <TextView
             android:id="@+id/won"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:layout_marginLeft="2dp"
-            android:textSize="17dp"
+            android:layout_marginLeft="1dp"
+            android:fontFamily="@font/nanum_square_b"
+            android:text="원"
             android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_r"
-            android:text="원" />
+            android:textSize="17dp" />
     </RelativeLayout>
+
 </LinearLayout>

--- a/app/src/main/res/layout/activity_item_detail.xml
+++ b/app/src/main/res/layout/activity_item_detail.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginVertical="15dp"
+    android:paddingTop="15dp"
+    android:paddingBottom="15dp"
     tools:context=".detail.ItemDetailActivity"
     android:orientation="vertical"
     android:background="@color/white">
@@ -20,13 +21,15 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp">
+        android:paddingHorizontal="15dp"
+        android:paddingTop="15dp"
+        android:paddingBottom="10dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="17dp"
+            android:textSize="15dp"
             android:textColor="@color/black"
             android:fontFamily="@font/nanum_square_eb"
             android:text="니트 / 가디건" />
@@ -42,125 +45,140 @@
             android:text="21. 5. 5." />
 
     </LinearLayout>
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
 
-            <ImageView
-                android:id="@id/item_image"
-                android:layout_width="match_parent"
-                android:layout_height="0dp"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent"
-                app:layout_constraintDimensionRatio="1:1"
-                android:scaleType="center"
-                android:src="@drawable/sample"/>
-
-            <FrameLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                app:layout_constraintEnd_toEndOf="@id/item_image"
-                app:layout_constraintBottom_toBottomOf="@id/item_image"
-                android:layout_margin="15dp"
-                android:layout_gravity="right|bottom">
-
-                <ImageView
-                    android:layout_width="72dp"
-                    android:layout_height="72dp"
-                    android:src="@drawable/round_sticker" />
-                <TextView
-                    android:id="@+id/d_day"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_gravity="center"
-                    android:textAllCaps="true"
-                    android:textSize="17dp"
-                    android:textColor="@color/black"
-                    android:fontFamily="@font/nanum_square_r"
-                    android:text="D-15" />
-            </FrameLayout>
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    <LinearLayout
+    <ScrollView
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1"
-        android:layout_margin="15dp"
-        android:orientation="vertical">
-        <TextView
-            android:id="@+id/item_name"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAllCaps="true"
-            android:textSize="17dp"
-            android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_eb"
-            android:text="[GROVE] 21 S/S RIA CARDIGAN - IVORY" />
-
+        android:layout_weight="1">
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp">
+            android:layout_height="match_parent"
+            android:orientation="vertical">
 
-            <TextView
-                android:id="@+id/item_price"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="20dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_eb"
-                android:text="129,000" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <TextView
-                android:id="@+id/won"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="2dp"
-                android:textSize="20dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="원" />
+                <ImageView
+                    android:id="@id/item_image"
+                    android:layout_width="match_parent"
+                    android:layout_height="0dp"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:layout_constraintDimensionRatio="1:1"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/sample"/>
 
+                <FrameLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    app:layout_constraintEnd_toEndOf="@id/item_image"
+                    app:layout_constraintBottom_toBottomOf="@id/item_image"
+                    android:layout_margin="15dp"
+                    android:layout_gravity="right|bottom">
+
+                    <ImageView
+                        android:layout_width="72dp"
+                        android:layout_height="72dp"
+                        android:src="@drawable/round_sticker" />
+                    <TextView
+                        android:id="@+id/d_day"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:textAllCaps="true"
+                        android:textSize="17dp"
+                        android:textColor="@color/black"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:text="D-15" />
+                </FrameLayout>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_weight="1"
+                android:padding="15dp"
+                android:orientation="vertical">
+                <TextView
+                    android:id="@+id/item_name"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textAllCaps="true"
+                    android:textSize="20dp"
+                    android:textColor="@color/black"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:text="GROVE 21 S/S RIA CARDIGAN - IVORY" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp">
+
+                    <TextView
+                        android:id="@+id/item_price"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="15dp"
+                        android:textColor="@color/black"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:text="129,000" />
+
+                    <TextView
+                        android:id="@+id/won"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="1dp"
+                        android:textSize="15dp"
+                        android:textColor="@color/black"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:text="원" />
+
+                </LinearLayout>
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp">
+                    <TextView
+                        android:id="@+id/noti_type"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:textSize="15dp"
+                        android:textColor="@color/black"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:text="[프리오더 마감]" />
+
+                    <TextView
+                        android:id="@+id/noti_date"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginLeft="10dp"
+                        android:textSize="15dp"
+                        android:textColor="@color/black"
+                        android:fontFamily="@font/nanum_square_b"
+                        android:text="21. 5. 5. 10시" />
+                </LinearLayout>
+                <TextView
+                    android:id="@+id/tag"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="15dp"
+                    android:paddingHorizontal="10dp"
+                    android:paddingVertical="5dp"
+                    android:background="@drawable/background_tag"
+                    android:textSize="15dp"
+                    android:textColor="@color/black"
+                    android:fontFamily="@font/nanum_square_b"
+                    android:text="S사이즈" />
+            </LinearLayout>
         </LinearLayout>
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp">
-            <TextView
-                android:id="@+id/noti_type"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textSize="15dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_b"
-                android:text="[프리오더 마감]" />
-
-            <TextView
-                android:id="@+id/noti_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="10dp"
-                android:textSize="15dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_b"
-                android:text="21. 5. 5." />
-        </LinearLayout>
-        <TextView
-            android:id="@+id/tag"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="15dp"
-            android:paddingHorizontal="10dp"
-            android:paddingVertical="5dp"
-            android:background="@color/pastelGreen"
-            android:textSize="15dp"
-            android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_r"
-            android:text="S사이즈" />
-    </LinearLayout>
+    </ScrollView>
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="15dp">
+        android:layout_marginTop="15dp"
+        android:paddingHorizontal="15dp">
         <LinearLayout
             android:layout_width="0dp"
             android:layout_height="wrap_content"
@@ -170,7 +188,7 @@
                 android:id="@+id/delete"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="15dp"
+                android:layout_marginLeft="2dp"
                 android:src="@drawable/delete"
                 android:background="@android:color/transparent" />
 
@@ -186,7 +204,7 @@
         <Button
             android:id="@+id/shopping"
             android:layout_width="0dp"
-            android:layout_height="50dp"
+            android:layout_height="40dp"
             android:layout_weight="1"
             android:outlineProvider="none"
             android:background="@drawable/button_green"

--- a/app/src/main/res/layout/activity_link_sharing.xml
+++ b/app/src/main/res/layout/activity_link_sharing.xml
@@ -1,180 +1,201 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"-->
+<?xml version="1.0" encoding="utf-8"?><!--<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"-->
 <!--    android:layout_width="match_parent"-->
 <!--    android:layout_height="wrap_content">-->
 
-    <FrameLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_alignParentBottom="true"
+    android:layout_gravity="bottom">
+
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignParentBottom="true"
-        android:layout_gravity="bottom">
-        <RelativeLayout
-            android:layout_width="match_parent"
+        android:layout_marginTop="40dp"
+        android:background="@drawable/background_popup"
+        android:padding="15dp">
+
+        <ImageButton
+            android:id="@+id/cancel"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginTop="40dp"
-            android:padding="15dp"
-            android:background="@drawable/background_popup">
+            android:layout_alignParentRight="true"
+            android:background="@android:color/transparent"
+            android:onClick="onClick"
+            android:src="@drawable/x" />
 
-            <ImageButton
-                android:id="@+id/cancel"
+        <RelativeLayout
+            android:id="@+id/content"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="40dp">
+
+            <TextView
+                android:id="@+id/item_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:onClick="onClick"
-                android:src="@drawable/x"
-                android:background="@android:color/transparent" />
+                android:layout_centerHorizontal="true"
+                android:fontFamily="@font/nanum_square_b"
+                android:text="PRETZEL PUFF KNIT"
+                android:textColor="@color/black"
+                android:textSize="15dp" />
 
-            <RelativeLayout
-                android:id="@+id/content"
+            <LinearLayout
+                android:id="@+id/content_price"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="40dp">
+                android:layout_below="@id/item_name"
+                android:layout_centerHorizontal="true"
+                android:layout_marginTop="15dp">
 
                 <TextView
-                    android:id="@+id/item_name"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_centerHorizontal="true"
-                    android:textSize="15dp"
-                    android:textColor="@color/black"
-                    android:fontFamily="@font/nanum_square_b"
-                    android:text="PRETZEL PUFF KNIT" />
-
-                <LinearLayout
-                    android:id="@+id/content_price"
+                    android:id="@+id/item_price"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_below="@id/item_name"
-                    android:layout_marginTop="15dp"
-                    android:layout_centerHorizontal="true">
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:text="219,000"
+                    android:textColor="@color/black"
+                    android:textSize="15dp" />
 
-                    <TextView
-                        android:id="@+id/item_price"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_below="@id/item_name"
-                        android:textSize="15dp"
-                        android:textColor="@color/black"
-                        android:fontFamily="@font/nanum_square_eb"
-                        android:text="219,000" />
-
-                    <TextView
-                        android:id="@+id/won"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginLeft="2dp"
-                        android:layout_alignTop="@id/item_price"
-                        android:layout_toRightOf="@id/item_price"
-                        android:textSize="15dp"
-                        android:textColor="@color/black"
-                        android:fontFamily="@font/nanum_square_b"
-                        android:text="원" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/noti_content"
-                    android:layout_width="match_parent"
+                <TextView
+                    android:id="@+id/won"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginTop="15dp"
-                    android:layout_below="@id/content_price">
+                    android:layout_alignTop="@id/item_price"
+                    android:layout_marginLeft="2dp"
+                    android:layout_toRightOf="@id/item_price"
+                    android:fontFamily="@font/nanum_square_b"
+                    android:text="원"
+                    android:textColor="@color/black"
+                    android:textSize="15dp" />
+            </LinearLayout>
 
-                    <!-- @param : android:background="@null" 기존 화살표 아이콘 제거 -->
-                    <Spinner
-                        android:id="@+id/noti_type_spinner"
-                        android:layout_width="0dp"
-                        android:layout_height="50dp"
-                        android:layout_weight="1.5"
-                        android:layout_below="@id/content_price"
-                        android:background="@null"/>
+            <LinearLayout
+                android:id="@+id/noti_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/content_price"
+                android:gravity="center_vertical">
 
-                    <!-- @see : https://hinos.tistory.com/18 -->
+                <!-- @param : android:background="@null" 기존 화살표 아이콘 제거 -->
+                <Spinner
+                    android:id="@+id/noti_type_spinner"
+                    android:layout_width="0dp"
+                    android:layout_height="50dp"
+                    android:layout_below="@id/content_price"
+                    android:layout_weight="1.5"
+                    android:background="@null" />
+
+                <FrameLayout
+                    android:layout_width="0dp"
+                    android:layout_height="60dp"
+                    android:layout_weight="2">
+
                     <LinearLayout
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="2"
+                        android:layout_width="match_parent"
+                        android:layout_height="60dp"
                         android:paddingLeft="5dp">
+
                         <NumberPicker
                             android:id="@+id/num_picker_date"
                             android:layout_width="0dp"
-                            android:layout_height="50dp"
+                            android:layout_height="match_parent"
                             android:layout_weight="4"
-                            android:theme="@style/AppTheme.NumberPicker"/>
+                            android:selectionDividerHeight="0dp"
+                            android:theme="@style/AppTheme.NumberPicker" />
+
                         <TextView
                             android:id="@+id/invisible_colon"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
-                            android:visibility="invisible"
-                            android:textSize="15dp"
                             android:fontFamily="@font/nanum_square_eb"
-                            android:text=":"/>
+                            android:text=":"
+                            android:textSize="15dp"
+                            android:visibility="invisible" />
+
                         <NumberPicker
                             android:id="@+id/num_picker_hour"
                             android:layout_width="0dp"
-                            android:layout_height="50dp"
+                            android:layout_height="match_parent"
                             android:layout_weight="1"
-                            android:theme="@style/AppTheme.NumberPicker"/>
+                            android:selectionDividerHeight="0dp"
+                            android:theme="@style/AppTheme.NumberPicker" />
+
                         <TextView
                             android:id="@+id/colon"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
                             android:layout_gravity="center_vertical"
-                            android:textSize="15dp"
-                            android:textColor="@color/black"
                             android:fontFamily="@font/nanum_square_eb"
-                            android:text=":"/>
+                            android:text=":"
+                            android:textColor="@color/black"
+                            android:textSize="15dp" />
+
                         <NumberPicker
                             android:id="@+id/num_picker_minute"
                             android:layout_width="0dp"
-                            android:layout_height="50dp"
+                            android:layout_height="match_parent"
                             android:layout_weight="1"
-                            android:theme="@style/AppTheme.NumberPicker"/>
+                            android:selectionDividerHeight="0dp"
+                            android:theme="@style/AppTheme.NumberPicker" />
 
                     </LinearLayout>
-                </LinearLayout>
 
-                <EditText
-                    android:id="@+id/item_memo"
-                    android:layout_width="match_parent"
-                    android:layout_height="50dp"
-                    android:layout_marginTop="15dp"
-                    android:padding="15dp"
-                    android:layout_below="@id/noti_content"
-                    android:gravity="center_vertical"
-                    android:textSize="15dp"
-                    android:textColorHint="@color/mediumGray"
-                    android:fontFamily="@font/nanum_square_b"
-                    android:hint="메모를 입력해보세요."
-                    android:inputType="text"/>
-    <!-- @deprecated : android:background="@drawable/background_memo" 배경추가할지 고민 중-->
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="22.5dp"
+                        android:layout_gravity="top"
+                        android:background="@color/white" />
 
-            </RelativeLayout>
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="22.5dp"
+                        android:layout_gravity="bottom"
+                        android:background="@color/white" />
+                </FrameLayout>
+            </LinearLayout>
 
-            <Button
-                android:id="@+id/add"
+            <EditText
+                android:id="@+id/item_memo"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:layout_marginTop="15dp"
-                android:layout_below="@id/content"
-                android:outlineProvider="none"
-                android:background="@drawable/button_green"
-                android:textSize="14dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_eb"
-                android:text="위시리스트에 추가"
-                android:onClick="onClick"/>
+                android:layout_below="@id/noti_content"
+                android:fontFamily="@font/nanum_square_b"
+                android:gravity="center_vertical"
+                android:hint="메모를 입력해보세요."
+                android:inputType="text"
+                android:paddingHorizontal="15dp"
+                android:textColorHint="@color/mediumGray"
+                android:textSize="15dp" />
+            <!-- @deprecated : android:background="@drawable/background_memo" 배경추가할지 고민 중-->
 
         </RelativeLayout>
-        <de.hdodenhof.circleimageview.CircleImageView
-            android:id="@+id/item_image"
-            android:layout_width="80dp"
-            android:layout_height="80dp"
-            android:layout_gravity="center_horizontal"
-            android:src="@drawable/sample" />
-    </FrameLayout>
+
+        <Button
+            android:id="@+id/add"
+            android:layout_width="match_parent"
+            android:layout_height="50dp"
+            android:layout_below="@id/content"
+            android:layout_marginTop="15dp"
+            android:background="@drawable/button_green"
+            android:fontFamily="@font/nanum_square_eb"
+            android:onClick="onClick"
+            android:outlineProvider="none"
+            android:text="위시리스트에 추가"
+            android:textColor="@color/black"
+            android:textSize="14dp" />
+
+    </RelativeLayout>
+
+    <de.hdodenhof.circleimageview.CircleImageView
+        android:id="@+id/item_image"
+        android:layout_width="80dp"
+        android:layout_height="80dp"
+        android:layout_gravity="center_horizontal"
+        android:src="@drawable/sample" />
+</FrameLayout>
 
 
-
-
-<!--</RelativeLayout>-->
+    <!--</RelativeLayout>-->

--- a/app/src/main/res/layout/cart_item.xml
+++ b/app/src/main/res/layout/cart_item.xml
@@ -2,39 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="15dp"
+    android:padding="15dp"
     android:background="@color/white">
-    <RelativeLayout
-        android:id="@+id/select"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        <CheckBox
-            android:id="@+id/check_white"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:button="@null"
-            android:checked="false"
-            android:layout_centerVertical="true"
-            android:onClick="onClick"
-            android:background="@drawable/custom_checkbox" />
-        <ImageButton
-            android:id="@+id/x"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentEnd="true"
-            android:layout_centerVertical="true"
-            android:onClick="onClick"
-            android:src="@drawable/x"
-            android:background="@android:color/transparent" />
-    </RelativeLayout>
 
     <ImageView
         android:id="@+id/item_image"
-        android:layout_width="80dp"
-        android:layout_height="80dp"
-        android:layout_marginTop="15dp"
-        android:layout_marginRight="15dp"
-        android:layout_below="@id/select"
+        android:layout_width="70dp"
+        android:layout_height="70dp"
+        android:layout_marginRight= "15dp"
         android:scaleType="centerCrop"
         android:src="@drawable/sample"/>
     <RelativeLayout
@@ -48,40 +23,51 @@
             android:layout_height="wrap_content"
             android:textSize="15dp"
             android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_r"
+            android:fontFamily="@font/nanum_square_b"
             android:text="ITEM NAME" />
-        <LinearLayout
+
+        <ImageButton
+            android:id="@+id/x"
+            android:layout_width="12dp"
+            android:layout_height="12dp"
+            android:layout_alignParentEnd="true"
+            android:onClick="onClick"
+            android:src="@drawable/x"
+            android:background="@android:color/transparent" />
+
+    </RelativeLayout>
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/item_image"
+        android:layout_alignBottom="@id/item_image"
+        android:layout_marginTop="10dp">
+        <ImageButton
+            android:id="@+id/minus"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_below="@id/item_name"
-            android:layout_marginTop="10dp">
-            <ImageButton
-                android:id="@+id/minus"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentEnd="true"
-                android:layout_centerVertical="true"
-                android:src="@drawable/minus"
-                android:background="@android:color/transparent" />
-            <TextView
-                android:id="@+id/quantity"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center_vertical"
-                android:layout_marginHorizontal="15dp"
-                android:textSize="15dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="1" />
-            <ImageButton
-                android:id="@+id/plus"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_centerVertical="true"
-                android:src="@drawable/plus"
-                android:background="@android:color/transparent" />
-        </LinearLayout>
-    </RelativeLayout>
+            android:layout_alignParentEnd="true"
+            android:layout_centerVertical="true"
+            android:src="@drawable/minus"
+            android:background="@android:color/transparent" />
+        <TextView
+            android:id="@+id/quantity"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_vertical"
+            android:layout_marginHorizontal="15dp"
+            android:textSize="15dp"
+            android:textColor="@color/black"
+            android:fontFamily="@font/nanum_square_r"
+            android:text="1" />
+        <ImageButton
+            android:id="@+id/plus"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:src="@drawable/plus"
+            android:background="@android:color/transparent" />
+    </LinearLayout>
     <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -101,10 +87,10 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentEnd="true"
-            android:layout_marginLeft="2dp"
+            android:layout_marginLeft="1dp"
             android:textSize="17dp"
             android:textColor="@color/black"
-            android:fontFamily="@font/nanum_square_r"
+            android:fontFamily="@font/nanum_square_b"
             android:text="원" />
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/folder_item.xml
+++ b/app/src/main/res/layout/folder_item.xml
@@ -8,7 +8,7 @@
     android:background="@color/white">
 
     <!-- @brief : 폴더화면 아이템 리스트 중 아이템 하나의 뷰 -->
-    <de.hdodenhof.circleimageview.CircleImageView
+    <ImageView
         android:id="@+id/folder_item"
         android:layout_width="match_parent"
         android:layout_height="0dp"
@@ -25,11 +25,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="2dp"
-        android:layout_marginTop="15dp"
-        android:fontFamily="@font/nanum_square_b"
+        android:layout_marginTop="7.5dp"
+        android:fontFamily="@font/nanum_square_eb"
         android:text="폴더명"
         android:textColor="@color/black"
-        android:textSize="15dp"
+        android:textSize="13dp"
         app:layout_constraintStart_toStartOf="@id/folder_item"
         app:layout_constraintTop_toBottomOf="@id/folder_item" />
 
@@ -37,8 +37,8 @@
         android:id="@+id/item_count"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        android:fontFamily="@font/nanum_square_eb"
+        android:layout_marginTop="5dp"
+        android:fontFamily="@font/nanum_square_b"
         android:text="11"
         android:textColor="@color/mediumGray"
         android:textSize="13dp"
@@ -49,10 +49,9 @@
         android:id="@+id/more"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="5dp"
         android:layout_marginRight="2dp"
         android:background="@android:color/transparent"
-        android:src="@drawable/more"
+        android:src="@drawable/folder_more"
         app:layout_constraintRight_toRightOf="@id/folder_item"
         app:layout_constraintTop_toTopOf="@id/folder_name"
         app:layout_constraintTop_toBottomOf="@id/folder_item"

--- a/app/src/main/res/layout/fragment_folder.xml
+++ b/app/src/main/res/layout/fragment_folder.xml
@@ -3,23 +3,23 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:orientation="vertical">
 
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
-        android:gravity="center">
+        android:gravity="center"
+        android:padding="15dp">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:textSize="20dp"
-            android:textColor="@color/black"
             android:fontFamily="@font/noto_sans_kr_bold"
-            android:text="Folder" />
+            android:text="Folder"
+            android:textColor="@color/black"
+            android:textSize="20dp" />
 
         <FrameLayout
             android:layout_width="wrap_content"
@@ -29,38 +29,33 @@
                 android:id="@+id/cart"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/cart"
-                android:background="@android:color/transparent" />
+                android:background="@android:color/transparent"
+                android:src="@drawable/cart" />
 
             <!-- @ TODO : 장바구니 아이템 수 표시하는 이미지 뷰 위치 조정 해결 못함 -->
             <ImageView
-                android:visibility="invisible"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:src="@drawable/item_cnt_circle"/>
+                android:src="@drawable/item_cnt_circle"
+                android:visibility="invisible" />
         </FrameLayout>
 
         <ImageButton
             android:id="@+id/new_folder"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
             android:layout_marginLeft="20dp"
-            android:src="@drawable/new_folder"
-            android:background="@android:color/transparent" />
+            android:background="@android:color/transparent"
+            android:src="@drawable/new_folder" />
     </LinearLayout>
-    <LinearLayout
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerview_folders_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
-
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerview_folders_list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:layout_margin="7.5dp"
-            android:scrollbarFadeDuration="0"
-            android:scrollbarSize="5dp"
-            android:scrollbarThumbVertical="@android:color/darker_gray"
-            android:scrollbars="vertical" />
-
-    </LinearLayout>
+        android:layout_height="match_parent"
+        android:padding="7.5dp"
+        android:scrollbarFadeDuration="0"
+        android:scrollbarSize="5dp"
+        android:scrollbarThumbVertical="@android:color/darker_gray"
+        android:scrollbars="vertical" />
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -10,7 +10,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
+        android:padding="15dp"
         android:gravity="center">
 
         <TextView
@@ -60,11 +60,11 @@
     </LinearLayout>
 
     <HorizontalScrollView
-        android:layout_marginBottom="10dp"
         android:id="@+id/category"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginHorizontal="15dp"
+        android:paddingHorizontal="15dp"
+        android:paddingBottom="10dp"
         android:scrollbars="none">
 
         <LinearLayout

--- a/app/src/main/res/layout/fragment_new_item.xml
+++ b/app/src/main/res/layout/fragment_new_item.xml
@@ -8,7 +8,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
+        android:padding="15dp"
         android:gravity="center">
         <TextView
             android:layout_width="wrap_content"
@@ -31,10 +31,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
-        android:layout_marginBottom="15dp"
-        android:fontFamily="@font/nanum_square_eb"
-        android:text="2021.05.10"
-        android:textColor="@color/mediumGray" />
+        android:layout_marginBottom="10dp"
+        android:textSize="13dp"
+        android:textColor="@color/mediumGray"
+        android:fontFamily="@font/nanum_square_r"
+        android:text="21. 5. 10." />
     <!-- @ TODO : ConstraintLayout 로 ImageView를 통일하기 -->
     <ScrollView
         xmlns:android="http://schemas.android.com/apk/res/android"
@@ -99,7 +100,7 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="2"
                         android:background="@android:color/transparent"
-                        android:fontFamily="@font/nanum_square_eb"
+                        android:fontFamily="@font/nanum_square_b"
                         android:gravity="right"
                         android:hint="상품명을 입력해주세요."
                         android:textSize="13dp" />
@@ -123,7 +124,7 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="2"
                         android:background="@android:color/transparent"
-                        android:fontFamily="@font/nanum_square_eb"
+                        android:fontFamily="@font/nanum_square_b"
                         android:gravity="right"
                         android:hint="가격을 입력해주세요."
                         android:textSize="13dp" />
@@ -147,7 +148,7 @@
                         android:layout_height="wrap_content"
                         android:layout_weight="2"
                         android:background="@android:color/transparent"
-                        android:fontFamily="@font/nanum_square_eb"
+                        android:fontFamily="@font/nanum_square_b"
                         android:gravity="right"
                         android:hint="쇼핑몰 링크를 입력해주세요."
                         android:textSize="13dp" />
@@ -188,7 +189,7 @@
                         android:layout_marginTop="15dp"
                         android:layout_weight="1"
                         android:background="@android:color/transparent"
-                        android:fontFamily="@font/nanum_square_eb"
+                        android:fontFamily="@font/nanum_square_b"
                         android:hint="메모를 작성해주세요. (메모 내용으로도 검색할 수 있어요!)"
                         android:textSize="13dp" />
                 </LinearLayout>

--- a/app/src/main/res/layout/fragment_noti.xml
+++ b/app/src/main/res/layout/fragment_noti.xml
@@ -8,7 +8,7 @@
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="15dp"
+        android:padding="15dp"
         android:gravity="center">
 
         <TextView
@@ -69,7 +69,7 @@
 <!-- @brief : 클릭이벤트에 따라 <View>의 visibility 속성값 변경-->
             <View
                 android:layout_width="match_parent"
-                android:layout_height="0.5dp"
+                android:layout_height="2dp"
                 android:background="@color/black"
                 android:visibility="visible"
                 />
@@ -91,7 +91,7 @@
                 android:text="캘린더 알림" />
             <View
                 android:layout_width="match_parent"
-                android:layout_height="0.5dp"
+                android:layout_height="2dp"
                 android:background="@color/black"
                 android:visibility="invisible"
                 />

--- a/app/src/main/res/layout/noti_item.xml
+++ b/app/src/main/res/layout/noti_item.xml
@@ -18,7 +18,7 @@
         android:layout_toRightOf="@id/item_image"
         android:textSize="15dp"
         android:textColor="@color/black"
-        android:fontFamily="@font/nanum_square_r"
+        android:fontFamily="@font/nanum_square_b"
         android:text="[오픈일 알림]"/>
     <TextView
         android:id="@+id/item_name"
@@ -28,7 +28,7 @@
         android:layout_marginLeft="10dp"
         android:textSize="15dp"
         android:textColor="@color/black"
-        android:fontFamily="@font/nanum_square_r"
+        android:fontFamily="@font/nanum_square_b"
         android:textAllCaps="true"
         android:text="21SS KEILY JACHKT"
         />
@@ -38,10 +38,8 @@
         android:layout_height="wrap_content"
         android:layout_alignLeft="@id/noti_type"
         android:layout_alignBottom="@id/item_image"
-        android:layout_marginLeft="10dp"
         android:textSize="15dp"
         android:textColor="@color/mediumGray"
         android:fontFamily="@font/nanum_square_r"
-        android:text="1시간 전"
-        />
+        android:text="1시간 전" />
 </RelativeLayout>

--- a/app/src/main/res/layout/wish_item.xml
+++ b/app/src/main/res/layout/wish_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginBottom="20dp"
@@ -35,7 +36,8 @@
         app:layout_constraintTop_toBottomOf="@id/item_image"
         android:layout_margin="10dp"
         android:textSize="13dp"
-        android:fontFamily="@font/nanum_square_r"
+        android:textColor="@color/black"
+        android:fontFamily="@font/nanum_square_eb"
         android:text="name" />
 
     <TextView
@@ -47,7 +49,7 @@
         android:layout_marginTop="10dp"
         android:textSize="13dp"
         android:textColor="@color/black"
-        android:fontFamily="@font/nanum_square_eb"
+        android:fontFamily="@font/nanum_square_b"
         android:text="price" />
 
     <TextView
@@ -56,10 +58,10 @@
         android:layout_height="wrap_content"
         app:layout_constraintTop_toTopOf="@id/item_price"
         app:layout_constraintStart_toEndOf="@id/item_price"
-        android:layout_marginLeft="2dp"
+        android:layout_marginLeft="1dp"
         android:textSize="13dp"
         android:textColor="@color/black"
-        android:fontFamily="@font/nanum_square_r"
+        android:fontFamily="@font/nanum_square_b"
         android:text="원" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values-v23/styles.xml
+++ b/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
+        <!-- Customize your theme here. -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorAccent">@color/colorAccent</item>
+        <!--Status Bar 배경색-->
+        <item name="android:statusBarColor">@android:color/white</item>
+        <!--Status Bar 글자색깔-->
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:includeFontPadding">false</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="pastelGreen">#EEFEEF</color>
     <color name="lightGray">#E3E3E3</color>
     <color name="mediumGray">#aaaaaa</color>
+    <color name="realBlack">#000000</color>
     <color name="black">#292929</color>
     <color name="white">#ffffff</color>
     <color name="transparent">#00000000</color>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -1,9 +1,10 @@
 <resources>
+    <!--v23이하에서 적용-->
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.NoActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
+        <item name="colorPrimaryDark">@color/realBlack</item>
         <item name="colorAccent">@color/colorAccent</item>
         <item name="android:includeFontPadding">false</item>
     </style>
@@ -22,7 +23,6 @@
         <item name="android:textSize">15dp</item>
         <item name="android:textColor">@color/black</item>
         <item name="android:fontFamily">@font/nanum_square_b</item>
-        <item name="android:paddingTop">10dp</item>
     </style>
 
 </resources>


### PR DESCRIPTION
ItemAdapter와 일부 xml에서 수정한 것입니다.

ItemAdapter
 홈에서 아이템 클릭 시 아이템 상세조회로 연결되도록 ItemAdapter 복구
xml
 메인 엑티비티 레이아웃에서 바텀네비게이션 뷰 배경컬러를 투명(회색으로 보임)에서 화이트로 수정하고 아이콘 사이즈 속성 추가(사이즈 약간 줄임)
 장바구니 레이아웃에서 이미지버튼을 체크버튼으로 수정, 파일명 수정(스펠링)
 카트, 알림 아이템 레이아웃에서 아이템 이미지 크기 줄이기
 카트 아이템에서 체크 박스 삭제, 각 뷰 위치 조정
 카트아이템에서 체크박스 크기 수정
 레이아웃 마진, 패딩 일부 수정
 초록버튼 radius 수정, 해시 태그 배경 추가
 폴더 아이템 내 더보기 버튼을 폴더 전용 더보기 버튼으로 변경, 아이템 이미지 정방형으로 복구
 넘버피커 구분선 없애기 (FrameLayout 내 넘버피커를 수직 중앙에 위치 배경색과 동일한 각형 뷰를 위아래 배치해서 구분선 가림 )