### PR TITLE
Hotfix:#124

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,7 @@
     <uses-permission android:name="android.permission.CAMERA" /> <!--카메라 권한-->
     <uses-feature android:name="android.hardware.camera" android:required="true"/> <!--카메라 기능 사용-->
 
+<!-- @param android:networkSecurityConfig="@xml/network_security_config" : http 프로토콜 접속 시 예외발생 조치를 위한 설정파일-->
     <application
         android:name=".sign.KakaoApplication"
         android:allowBackup="true"
@@ -18,6 +19,7 @@
         android:roundIcon="@mipmap/ic_main_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
+        android:networkSecurityConfig="@xml/network_security_config"
         tools:ignore="Instantiatable">
 
         <activity android:name=".IntroActivity">

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
@@ -20,7 +20,7 @@ import retrofit2.http.Query;
 public interface IRemoteService {
 
     //@brief : 네트워크 설정
-    String BASE_URL = "http://13.125.227.20/"; // @brief : IP 주소 적기
+    String BASE_URL = "http://ec2-13-125-227-20.ap-northeast-2.compute.amazonaws.com/"; // @brief : IP 주소 적기 13.125.227.20
     String IMAGE_URL = "https://wishboardbucket.s3.ap-northeast-2.amazonaws.com/wishboard/";
     /*@brief : 각 요청 URL
     String NEW_ITEM_URL = BASE_URL+"/item/";

--- a/app/src/main/java/com/hyeeyoung/wishboard/sign/SignupActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/sign/SignupActivity.java
@@ -54,8 +54,6 @@ public class SignupActivity extends AppCompatActivity {
 
         edit_email.setOnFocusChangeListener((view, b) -> {
             email = edit_email.getText().toString();
-            // @deprecated : test 용
-//            email = "hyee1@sungshin.ac.kr";
             isValidId();
         });
     }
@@ -80,9 +78,6 @@ public class SignupActivity extends AppCompatActivity {
                 // @brief : 비밀번호 유효성 검사
                 isValidPassWd();
 
-                // @TODO: 해야 할 일
-                // @breif : 서버 연결하여 DB에 저장
-                save(email, pw_re);
                 /**
                  * @see : 서버와 연결 성공하면 token 값을 생성, 이 값과 함께 db에 저장
                  *         이후 이 token 값은 로그인 화면에서 사용?
@@ -90,7 +85,9 @@ public class SignupActivity extends AppCompatActivity {
 
                 // @brief : 회원가입 성공하여 로그인 화면으로 이동
                 if(isCheckId && isCheckPw) {
-                    Toast.makeText(this, "회원가입에 성공하였습니다!", Toast.LENGTH_SHORT).show();
+                    // @breif : 서버 연결하여 DB에 저장
+                    save(email, pw_re);
+                    Toast.makeText(this, "회원가입에 성공했습니다!", Toast.LENGTH_SHORT).show();
                     // @see : 토스트 확인 후 로그인 화면으로 넘어갈 수 있도록 delay 발생시킴
                     Handler timer = new Handler();
                     timer.postDelayed(() -> {
@@ -120,9 +117,6 @@ public class SignupActivity extends AppCompatActivity {
     private void isValidPassWd(){
         pw = edit_pw.getText().toString();
         pw_re = edit_pw_re.getText().toString();
-        // @deprecated : test 용
-//        pw = "abcde2021!";
-//        pw_re = "abcde2021!";
 
         // @brief :
         Pattern PASSWORD_PATTENRN = Pattern.compile("^(?=.*[A-Za-z])(?=.*[0-9])(?=.*[$@$!%*#?&]).{8}.$");
@@ -158,7 +152,9 @@ public class SignupActivity extends AppCompatActivity {
      * @prams : Retrofit을 이용하여 서버에 데이터 값 저장하는 함수
      * */
     private void save(String email, String pw_re){
-        user_item = new UserItem(null, email, pw_re, true, ""); //option_noti는 초기값 true
+        //user_item = new UserItem(null, email, pw_re, true, ""); // @brief : option_noti는 초기값 true
+        user_item = new UserItem(null, email, pw_re, true, ""); // @brief : option_noti는 초기값 true
+        Log.e("회원정보 등록", "정보" + email + ", "+ pw_re);
 
         // @brief : Retrofit
         IRemoteService remote_service = ServiceGenerator.createService(IRemoteService.class);
@@ -183,6 +179,7 @@ public class SignupActivity extends AppCompatActivity {
             public void onFailure(Call<ResponseBody> call, Throwable t) {
                 // @brief : 통식 실패 ()시 callback (예외 발생, 인터넷 끊김 등의 시스템적 이유로 실패)
                 Log.e("회원정보 등록", "서버 연결 실패");
+                //Log.i("회원정보 등록", "onFailure: " + t.getMessage());
             }
         });
     }

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<!-- http 프로토콜 접속 시 예외발생 조치를 위해 서버 도매인에 한해 http 주소를 허용(평문 접근 허용)-->
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">ec2-13-125-227-20.ap-northeast-2.compute.amazonaws.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
`SignupActivity.java`에서 user_item 저장 시 서버연결에러 문제를 해결했습니다.
그 외로 회원가입 로직에서 회원정보 저장 순서를 변경했습니다.

안드로이드 9.0 파이이상에서는 https를 사용하도록 강제하는데, 네트워크 경로가 https가 아닌 http (`IRemoteService.java`에서 서버주소로 http를 사용)로 되어 있기 때문에 발생한 문제였습니다.
[참고사이트에서 2번 방법으로 해결](https://gun0912.tistory.com/80)

- 'AdroidManifast.xml' 에서 application 내 android:networkSecurityConfig="@xml/network_security_config" 추가해서 네트워크 설정파일 경로를 지정
-  `res/xml/network_security_config.xml` 추가해서 현재 테스트 서버의 도메인만 http 주소로 접속 허용 
    - 추후 서버 주소를 AWS에서 Route53를 사용하여 https로 구성할 예정

- `SignupActivity.java`에서 이메일과 패스워드의 유효성검사( if(isCheckId && isCheckPw) )를 통과했을 때 save()가 실행되도록 순서를 조정했습니다.
