### PR TITLE
Mod:#93

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/IntroActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/IntroActivity.java
@@ -25,7 +25,7 @@ public class IntroActivity extends AppCompatActivity {
                 intent = new Intent(IntroActivity.this, MainActivity.class);
             }
 
-            intent = new Intent(IntroActivity.this, MainActivity.class); // @deprecated : 추후 로그인 완벽 구현 시 삭제 예정
+//            intent = new Intent(IntroActivity.this, MainActivity.class); // @deprecated : 추후 로그인 완벽 구현 시 삭제 예정
             startActivity(intent);
             finish(); // @brief : Activity 화면 제거
         }

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
@@ -45,16 +45,12 @@ public interface IRemoteService {
     @GET("/basket/{user_id}")
     Call<ArrayList<CartItem>> selectCartInfo(@Path("user_id") String user_id);
 
-    /* @see : delete의 경우 body로 숨겨서 전달해야 함!!
-     *        retrofit에서 제공하는 @DELETE 어노테이션을 이용하여 전달할 때는 Body로 전달 할 수 없음
-     *        HTTP 어노테이션을 사용하여 전달
-     *        @DELETE 어노테이션을 이용할 경우, @Path로 전달 가능
+    /* @see : delete의 경우 body로 숨겨서 전달할 경우, HTTP 어노테이션을 사용하여 전달
+     *        retrofit에서 제공하는 @DELETE 어노테이션을 이용할 경우, @Path로 전달 가능
      *        참고 사이트 : https://square.github.io/retrofit/2.x/retrofit/retrofit2/http/HTTP.html
      */
-//    @DELETE("/basket/{user_id}/{item_id}")
-//    Call<CartItem> deleteCartInfo(@Path("user_id") String user_id, @Path("item_id") String item_id);
     @HTTP(method = "DELETE", path = "/basket", hasBody = true)
-    Call<CartItem> deleteCartInfo(@Body CartItem cart_item); // @brief : delete의 경우 body로 숨겨서 전달해야 함!!
+    Call<CartItem> deleteCartInfo(@Body CartItem cart_item);
 
     /*
     @brief :

--- a/app/src/main/java/com/hyeeyoung/wishboard/sign/SignupActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/sign/SignupActivity.java
@@ -17,6 +17,7 @@ import com.hyeeyoung.wishboard.R;
 import com.hyeeyoung.wishboard.model.UserItem;
 import com.hyeeyoung.wishboard.remote.IRemoteService;
 import com.hyeeyoung.wishboard.remote.ServiceGenerator;
+import com.kakao.sdk.user.model.User;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -32,7 +33,7 @@ public class SignupActivity extends AppCompatActivity {
     private String pw; // @params : DB에 들어갈 사용자 pw
     private String pw_re;  //@deprecated : DB에 안넣고 이 안에서 유효성 검사 시 필요
     private boolean option_noti = true; // @parmas : DB에 들어갈 사용자 option_noti //기본값 true
-    private UserItem user_item;
+    //public UserItem user_item;
 
     private boolean isCheckPw = false;
     private boolean isCheckId = false;
@@ -72,15 +73,9 @@ public class SignupActivity extends AppCompatActivity {
                 // @brief : 오른쪽 -> 왼쪽으로 화면 전환
                 overridePendingTransition(R.anim.slide_left_enter, R.anim.slide_left_exit);
                 break;
-
             case R.id.btn_signup:
                 // @brief : 비밀번호 유효성 검사
                 isValidPassWd();
-
-                /**
-                 * @see : 서버와 연결 성공하면 token 값을 생성, 이 값과 함께 db에 저장
-                 *         이후 이 token 값은 로그인 화면에서 사용?
-                 */
 
                 // @brief : 회원가입 성공하여 로그인 화면으로 이동
                 if(isCheckId && isCheckPw) {
@@ -135,6 +130,10 @@ public class SignupActivity extends AppCompatActivity {
 
         }
     }
+
+    /**
+     * @breif : 회원가입 가능 시 버튼이 초록색으로 변경
+     */
     private void setBtnBackgroud(){
         if(isCheckId){ // @brief : 아이디도 입력되어 있다면,
             Drawable bg_btn_green = getResources().getDrawable(R.drawable.button_green);
@@ -148,13 +147,18 @@ public class SignupActivity extends AppCompatActivity {
 
     }
     /**
-     * @prams : Retrofit을 이용하여 서버에 데이터 값 저장하는 함수
+     * @brief : Retrofit을 이용하여 서버에 데이터 값 저장하는 함수
+     * @param email 이메일 주소
+     * @param pw_re 재입력한 비밀번호
+     * @see : private -> public static으로 변경. SigninActivity에서 카카오/구글 로그인 시 user_id 저장을 위해
      * */
-    private void save(String email, String pw_re){
-        user_item = new UserItem(null, email, pw_re, true, ""); // @brief : option_noti는 초기값 true
-        //Log.e("회원정보 등록", "정보" + email + ", "+ pw_re);
+    public static void save(String email, String pw_re){
+        // @brief : 카카오, 구글로 로그인하는 경우 -> pw가 없으므로
+        if(pw_re.equals("")) pw_re = "0";
 
-        // @brief : Retrofit
+        UserItem user_item = new UserItem(null, email, pw_re, true, ""); // @brief : option_noti는 초기값 true
+
+        // @brief : Retrofit 통신을 통해 서버에 user 정보 저장 요청
         IRemoteService remote_service = ServiceGenerator.createService(IRemoteService.class);
         Call<ResponseBody> call = remote_service.signUpUser(user_item);
         call.enqueue(new Callback<ResponseBody>(){


### PR DESCRIPTION
1. `IRemoteService.java` 
 - 주석 설명 추가
 
2. `SigninActivity.java`
- 카카오, 구글 Log 태그명 수정
- 카카오, 구글 email 정보 받아서 SignupActivity의 save함수 통과하도록 설정
- save함수 이후 signinWish() 로그인 하도록 수정
-> 구동이 완벽하지 않음
```
#문제 상황
1. 주석에도 명시해두었지만 이 로직이 맞는지 보안상의 문제가 있어 보여서 조금 더 다른 방법 고안 필요 
2. 처음엔 로그인 실패(구글, 카카오의 로그인 실패가 아닌 wish 로그인 실패) 뜨고 재차 한 번 더 눌러줘야 로그인 됨
  2.1. wishlogin대신 oauth로그인 함수를 따로 만들되, 같은 retrofit api로 통신하도록 할지 고민 중에 있음
```
3. `SignupActivity.java`
- save함수에 주석 추가
- save함수 private에서 public static으로 수정