### PR TITLE
Feature:#156

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/adapter/NotiAdapter.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/adapter/NotiAdapter.java
@@ -1,34 +1,35 @@
 package com.hyeeyoung.wishboard.adapter;
 
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
-
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
-
 import com.hyeeyoung.wishboard.R;
+import com.hyeeyoung.wishboard.util.Util;
 import com.hyeeyoung.wishboard.model.NotiItem;
-
+import com.squareup.picasso.Picasso;
 import java.util.ArrayList;
 
 public class NotiAdapter extends RecyclerView.Adapter<NotiAdapter.CustomViewHolder> {
     private ArrayList<NotiItem> notiList;
-
+    private int noti_layout_color; // @brief : 읽지 않은 알림의 배경에 적용할 색상
     public class CustomViewHolder extends RecyclerView.ViewHolder {
         protected ImageView item_image;
-        protected TextView item_name;
-        protected TextView noti_type;
+        protected TextView noti_title;
         protected TextView noti_date;
+        protected RelativeLayout noti_layout;
 
         public CustomViewHolder(View view) {
             super(view);
-            this.item_image = (ImageView) view.findViewById(R.id.item_image);
-            this.item_name = (TextView) view.findViewById(R.id.item_name);
-            this.noti_type = (TextView) view.findViewById(R.id.noti_type);
-            this.noti_date = (TextView) view.findViewById(R.id.noti_date);
+            this.item_image = view.findViewById(R.id.item_image);
+            this.noti_title = view.findViewById(R.id.noti_title);
+            this.noti_date = view.findViewById(R.id.noti_date);
+            this.noti_layout = view.findViewById(R.id.noti_layout);
         }
     }
     public NotiAdapter(ArrayList<NotiItem> data) {
@@ -40,8 +41,8 @@ public class NotiAdapter extends RecyclerView.Adapter<NotiAdapter.CustomViewHold
 
         View view = LayoutInflater.from(viewGroup.getContext())
                 .inflate(R.layout.noti_item, viewGroup, false);
-
         CustomViewHolder viewHolder = new CustomViewHolder(view);
+        noti_layout_color = view.getResources().getColor(R.color.pastelGreen);
 
         return viewHolder;
     }
@@ -49,10 +50,21 @@ public class NotiAdapter extends RecyclerView.Adapter<NotiAdapter.CustomViewHold
     @Override
     public void onBindViewHolder(@NonNull CustomViewHolder viewholder, int position) {
         NotiItem item = notiList.get(position);
-        viewholder.item_image.setImageResource(item.getItem_image());
-        viewholder.item_name.setText(item.getItem_name());
-        viewholder.noti_type.setText(item.getItem_notification_type());
-        viewholder.noti_date.setText(item.getItem_notification_date());
+
+        /**
+         * @brief : 아이템 이미지를 화면에 보여준다.
+         */
+        try {
+            Picasso.get().load(item.getItem_image()).into(viewholder.item_image); // @brief : 가져온 이미지경로값으로 이미지뷰 디스플레이
+        } catch (IllegalArgumentException i) {
+            Log.d("checkings", "아이템 사진 없음");
+        }
+
+        // @brief : 읽지 않은 알림인 경우 배경색을 설정
+        if(item.getIs_read() == "0")
+            viewholder.noti_layout.setBackgroundColor(noti_layout_color);
+        viewholder.noti_title.setText("[" + item.getItem_notification_type() + "] " + item.getItem_name());
+        viewholder.noti_date.setText(Util.beforeTime(item.getItem_notification_date()));
     }
     @Override
     public int getItemCount() {

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/NotiItem.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/NotiItem.java
@@ -1,10 +1,9 @@
 package com.hyeeyoung.wishboard.model;
 
 public class NotiItem {
-    private int item_image; // @param : 서버연동 후 String으로 변경 예정
-    private String item_name;
-    // @parmas : 서버와 연동하기 위해 사용될 변수
-    private String user_id, item_id,item_notification_type, item_notification_date;
+    // @breif : 서버와 연동하기 위해 사용될 변수
+    // @params is_read : 알림 읽음 여부
+    private String user_id, item_id, item_name, item_image, item_notification_type, item_notification_date, is_read;
 
     public NotiItem() {
     }
@@ -13,12 +12,16 @@ public class NotiItem {
         return user_id;
     }
 
-    public int getItem_image() {
+    public String getItem_image() {
         return item_image;
     }
 
     public String getItem_name() {
         return item_name;
+    }
+
+    public String getIs_read() {
+        return is_read;
     }
 
     public String getItem_notification_type() {
@@ -37,10 +40,6 @@ public class NotiItem {
         this.item_id = item_id;
     }
 
-    public void setItem_image(int item_image) {
-        this.item_image = item_image;
-    }
-
     public void setItem_name(String item_name) {
         this.item_name = item_name;
     }
@@ -56,10 +55,11 @@ public class NotiItem {
     @Override
     public String toString() {
         return "NotiItem{" +
-                ", user_id='" + user_id + '\'' +
-                ", item_id='" + item_id + '\'' +
-                ", noti_date='" + item_notification_date + '\'' +
-                ", noti_type='" + item_notification_type + '\'' +
+                "item_name='" + item_name + '\'' +
+                ", item_img='" + item_image + '\'' +
+                ", item_notification_type='" + item_notification_type + '\'' +
+                ", item_notification_date='" + item_notification_date + '\'' +
+                ", is_read='" + is_read + '\'' +
                 '}';
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiFragment.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiFragment.java
@@ -1,6 +1,7 @@
 package com.hyeeyoung.wishboard.noti;
 
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -14,9 +15,16 @@ import com.hyeeyoung.wishboard.R;
 import com.hyeeyoung.wishboard.adapter.NotiAdapter;
 import com.hyeeyoung.wishboard.model.NotiItem;
 
+import com.hyeeyoung.wishboard.remote.IRemoteService;
+import com.hyeeyoung.wishboard.remote.ServiceGenerator;
 import com.hyeeyoung.wishboard.service.SaveSharedPreferences;
 
 import java.util.ArrayList;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 
 /**
  * A simple {@link Fragment} subclass.
@@ -63,10 +71,11 @@ public class NotiFragment extends Fragment {
             mParam2 = getArguments().getString(ARG_PARAM2);
         }
     }
+
+    private static final String TAG = "알림 조회";
     private View view;
     RecyclerView recyclerView;
     NotiAdapter adapter;
-    private ArrayList<NotiItem> notiList;
     private LinearLayoutManager linearLayoutManager;
 
     private String user_id = "";
@@ -74,50 +83,99 @@ public class NotiFragment extends Fragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         view = inflater.inflate(R.layout.fragment_noti, container, false);
-        init();
-
         if(SaveSharedPreferences.getUserId(this.getActivity()).length() != 0)
             user_id = SaveSharedPreferences.getUserId(this.getActivity());
-
         return view;
     }
 
-    private void init() {
+    @Override
+    public void onStart() {
+        super.onStart();
+        selectNotiInfo(user_id); // @ brief : 알림 정보를 요청
+    }
+
+    @Override
+    public void onStop() {
+        super.onStop();
+        updateNotiRead(user_id); // @ brief : 알림 읽음 여부 업데이트 업데이트 요청
+    }
+
+    private void init(ArrayList<NotiItem> noti_list) {
         recyclerView = view.findViewById(R.id.recyclerview_noti_list);
-        notiList = new ArrayList<>();
-        adapter = new NotiAdapter(notiList);
+        adapter = new NotiAdapter(noti_list);
         recyclerView.setAdapter(adapter);
         recyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL));
         linearLayoutManager = new LinearLayoutManager(this.getActivity());
         recyclerView.setLayoutManager(linearLayoutManager);
-
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-        addNoti(R.drawable.sample, "가방", "[재입고 알림]", "1시간 전");
-
-        adapter.notifyDataSetChanged();
-    }
-    // @deprecated
-    private void addNoti(int icon, String mainText, String notiType, String notiDate) {
-        NotiItem item = new NotiItem();
-        item.setItem_image(icon);
-        item.setItem_name(mainText);
-        item.setItem_notification_type(notiType);
-        item.setItem_notification_date(notiDate);
-        notiList.add(item);
     }
 
-    /* @deprecated
-    private void addItem(Drawable icon, String mainText, String subText) {
-        WishItem item = new WishItem();
-        item.setItem_image(icon);
-        item.setItem_name(mainText);
-        item.setItem_price(subText);
-        wishList.add(item);
-    }*/
+    /**
+     * @brief : 서버에서 알림 정보를 조회한다.
+     * @param user_id 사용자 아이디
+     */
+    private void selectNotiInfo(String user_id) {
+        IRemoteService remoteService = ServiceGenerator.createService(IRemoteService.class);
+        Call<ArrayList<NotiItem>> call = remoteService.selectNotiInfo(user_id);
+        call.enqueue(new Callback<ArrayList<NotiItem>>() {
+            @Override
+            public void onResponse(Call<ArrayList<NotiItem>> call, Response<ArrayList<NotiItem>> response) {
+                ArrayList<NotiItem> noti_list = response.body();
+
+                // @brief : 가져온 알림이 없는 경우
+                if (noti_list == null) {
+                    noti_list = new ArrayList<>(); // @brief : 아이탬 배열 초기화
+                }
+
+                // @brief : 서버연결 성공한 경우
+                if(response.isSuccessful()){
+                    if (noti_list.size() > 0) { // @brief : 가져온 알림이 하나 이상인 경우
+                        Log.i(TAG, "Retrofit 통신 성공");
+                        Log.i(TAG, noti_list +""); // @deprecated : 테스트용
+                        init(noti_list); // @brief : onCreateView 메서드에서 해당 위치로 옮김
+                    }
+                } else { // @brief : 통신에 실패한 경우
+                    Log.i(TAG, "Retrofit 통신 실패" + response.message());
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ArrayList<NotiItem>> call, Throwable t) {
+                // @brief : 통신 실패 ()시 callback (예외 발생, 인터넷 끊김 등의 시스템적 이유로 실패)
+                Log.i(TAG, "서버 연결 실패" + t.getMessage());
+            }
+        });
+    }
+
+    /**
+     * @brief : 서버로 알림 읽음 여부 업데이트를 요청한다. (읽지 않은 알림을 읽음으로 업데이트)
+     * @param user_id 사용자 아이디
+     */
+    private void updateNotiRead(String user_id) {
+        IRemoteService remoteService = ServiceGenerator.createService(IRemoteService.class);
+        Call<ResponseBody> call = remoteService.updateNotiRead(user_id);
+        call.enqueue(new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                // @brief : 서버연결 성공한 경우
+                if (response.isSuccessful()) {
+                    String seq = null;
+                    try{
+                        seq = response.body().string();
+                    }catch (Exception e){
+                        e.printStackTrace();
+                    }
+                    Log.i(TAG, "업데이트 성공 [seq : " + seq + "]");
+                } else {
+                    // @brief : 통신에 실패한 경우
+                    Log.e(TAG, "업데이트 오류 [message : " + response.message() + "]");
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable t) {
+                // @brief : 통신 실패 ()시 callback (예외 발생, 인터넷 끊김 등의 시스템적 이유로 실패)
+                Log.i(TAG, "서버 연결 실패 [message : " + t.getMessage() + "]");
+            }
+        });
+    }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/remote/IRemoteService.java
@@ -1,19 +1,14 @@
 package com.hyeeyoung.wishboard.remote;
 
-import com.hyeeyoung.wishboard.adapter.CartAdapter;
 import com.hyeeyoung.wishboard.model.CartItem;
 import com.hyeeyoung.wishboard.model.NotiItem;
 import com.hyeeyoung.wishboard.model.UserItem;
 import com.hyeeyoung.wishboard.model.WishItem;
-
 import java.util.ArrayList;
-
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.http.Body;
 import retrofit2.http.DELETE;
-import retrofit2.http.Field;
-import retrofit2.http.FormUrlEncoded;
 import retrofit2.http.GET;
 import retrofit2.http.HTTP;
 import retrofit2.http.POST;
@@ -38,9 +33,10 @@ public interface IRemoteService {
     @POST("/item")
     Call<ResponseBody> insertItemInfo(@Body WishItem wish_item);
 
-    // @brief : 알림 정보 저장 요청
-    @POST("/noti")
-    Call<ResponseBody> insertItemNoti(@Body NotiItem noti_item);
+    // @brief : 홈화면에서 로그인한 사용자의 아이템 정보를 요청
+    @GET("/noti/{user_id}")
+    Call<ArrayList<NotiItem>> selectNotiInfo(@Path("user_id") String user_id);
+
 
     // @brief : wishbaord 앱 회원가입 요청
     @POST("/user/signup")
@@ -93,4 +89,12 @@ public interface IRemoteService {
     // @brief : 아이템 상세조회에서 아이템 삭제
     @DELETE("/item/detail/{item_id}")
     Call<Void> deleteItem(@Path("item_id") String item_id);
+
+    // @brief : 알림 정보 저장 요청
+    @POST("/noti")
+    Call<ResponseBody> insertItemNoti(@Body NotiItem noti_item);
+
+    // @brief : 알림화면에서 사용자가 조회한 알림은 읽은 알림으로 수정 요청
+    @PUT("/noti/{user_id}")
+    Call<ResponseBody> updateNotiRead(@Path("user_id") String user_id);
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/util/Util.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/util/Util.java
@@ -1,0 +1,50 @@
+package com.hyeeyoung.wishboard.util;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+
+public class Util {
+
+    // @breif : 현제 시간과 알림 시간의 차이
+    private static class TIME_MAXIMUM{ // @ brief : 시간 단위 별 최댓값
+        public static final int SEC = 60;
+        public static final int MIN = 60;
+        public static final int HOUR = 24;
+        public static final int WEEK = 7;
+    }
+
+    public static String beforeTime(String str_date){
+        SimpleDateFormat date_format = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Date date = null;
+        try {
+            date = date_format.parse(str_date);
+        } catch (ParseException e) {
+            e.printStackTrace();
+        }
+
+        Calendar c = Calendar.getInstance();
+        long now = c.getTimeInMillis();
+        long before = date.getTime();
+        long gap = (now - before) / 1000; // @breif : 현제 시간과 알림 시간의 차이
+
+        String msg = ""; // @breif : 알림 아이템에 디스플레이 될 시간 메세지
+
+        // @brief : 시간 차이에 따른 출력 될 알림 메세지 지정
+        if (gap < TIME_MAXIMUM.SEC) {
+            msg = "방금 전";
+        } else if ((gap /= TIME_MAXIMUM.SEC) < TIME_MAXIMUM.MIN) {
+            msg = gap + "분 전";
+        } else if ((gap /= TIME_MAXIMUM.MIN) < TIME_MAXIMUM.HOUR) {
+            msg = (gap) + "시간 전";
+        } else if ((gap /= TIME_MAXIMUM.HOUR) < TIME_MAXIMUM.WEEK) {
+            msg = (gap) + "일 전";
+        } else {
+            gap /= TIME_MAXIMUM.WEEK;
+            msg = (gap) + "주 전";
+        }
+
+        return msg;
+    }
+}

--- a/app/src/main/res/layout/noti_item.xml
+++ b/app/src/main/res/layout/noti_item.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/noti_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_margin="15dp"
+    android:padding="15dp"
     android:background="@color/white">
 
     <de.hdodenhof.circleimageview.CircleImageView
@@ -11,32 +12,21 @@
         android:layout_height="60dp"
         android:src="@drawable/sample" />
     <TextView
-        android:id="@+id/noti_type"
-        android:layout_width="wrap_content"
+        android:id="@+id/noti_title"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginLeft="15dp"
         android:layout_toRightOf="@id/item_image"
         android:textSize="15dp"
         android:textColor="@color/black"
         android:fontFamily="@font/nanum_square_b"
-        android:text="[오픈일 알림]"/>
-    <TextView
-        android:id="@+id/item_name"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@id/noti_type"
-        android:layout_marginLeft="10dp"
-        android:textSize="15dp"
-        android:textColor="@color/black"
-        android:fontFamily="@font/nanum_square_b"
-        android:textAllCaps="true"
-        android:text="21SS KEILY JACHKT"
-        />
+        android:text="[오픈일 알림] 21SS KEILY JACHKT 1234578srt9/"/>
+
     <TextView
         android:id="@+id/noti_date"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_alignLeft="@id/noti_type"
+        android:layout_alignLeft="@id/noti_title"
         android:layout_alignBottom="@id/item_image"
         android:textSize="15dp"
         android:textColor="@color/mediumGray"


### PR DESCRIPTION
[안드로이드] 알림 추가 및 수정을 구현했습니다.
1. 'NotiFragment.java'
- 기존에 테스트용으로 사용하던 `addNoti()`와 해당 메서드 호출 부분 삭제 
  - 'addNoti()` : 테스트용 알림 데이터 생성
- `selectNotiInfo()` 추가 : 서버에서 알림 정보를 조회 
- `updateNotiRead` 추가 : 서버로 알림 읽음 여부 업데이트를 요청 (읽지 않은 알림을 읽음으로 업데이트) 

2. `NotiItem.java`
- 테스트용 `int item_image` 변수 삭제 및 get, set 메서드 삭제
- `getIs_read()` 추가 : 알림 읽음 여부 가져오기

3. `NotiAdapter.java`
- 읽지 않은 알림에 대해 배경색 적용
- 디스플레이될 알림 제목과 시간 형식을 변경

4. Util
- 지난 알림의 날짜 형식을 바꾸기 위해 현재 날짜와 파라미터의 날짜 차이를 계산
-  표기방식은 방금 전, n분 전, n시간 전, n일 전, n주 전의 형식으로 출력

5. `IRemoteService.java`
-  insertItemNoti() 등록 : 알림 정보 저장 요청
-  updateItemNoti() 등록 : 알림화면에서 사용자가 조회한 알림은 읽은 알림으로 수정 요청

6. `noti_item.xml`
- 읽지 않은 알림의 배경색을 변경하기 위해 배경 레이아웃에 id값 추가