### PR TITLE
Mod:#156

### DIFF
--- a/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/MainActivity.java
@@ -36,22 +36,6 @@ public class MainActivity extends AppCompatActivity {
     private NotiFragment notiFragment;
     private MyFragment myFragment;
 
-    @Override
-    protected void onStart() {
-        super.onStart();
-        init();
-
-        // @ brief : 푸시알림을 클릭해서 메인화면을 들어올 경우 flag 값(3 : 알림 프래그먼트) 받아오고, 그렇지 않은 경우 default flag 값(0 : 홈 프래그먼트)으로 설정한다.
-        int flag = 0;
-        Bundle extras = getIntent().getExtras();
-        if(extras != null) {
-            flag = extras.getInt("flag");
-        }
-        //int flag = intent.getIntExtra("flag", 0);
-        Log.i(TAG, "onStart: " + flag);
-        // @brief 초기 프래그먼트 화면 지정
-        setFrag(flag);
-    }
     public void init(){
         newItemFragment = new NewItemFragment();
         folderFragment = new FolderFragment();
@@ -90,12 +74,15 @@ public class MainActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
+        init();
+        int flag = 0;
+        setFrag(flag);
 
         if(SaveSharedPreferences.getUserId(this).length() != 0)
             user_id = SaveSharedPreferences.getUserId(this);
 
+        // @brief : 파이어베이스 토큰 조회 코드
         if(SaveSharedPreferences.getFCMToken(this).length() == 0){
-            // @brief : 파이어베이스 토큰 조회 코드
             FirebaseMessaging.getInstance().getToken()
                     .addOnCompleteListener(new OnCompleteListener<String>() {
                         @Override
@@ -109,29 +96,9 @@ public class MainActivity extends AppCompatActivity {
                             String token = task.getResult();
                             SaveSharedPreferences.setFCMToken(MainActivity.this, token);
                             Log.i(TAG, "onComplete : " + SaveSharedPreferences.getFCMToken(MainActivity.this));
-                            // Log and toast
-                            //String msg = getString(R.string.msg_token_fmt, token);
-                            //Log.d(TAG, msg);
-                            //Toast.makeText(MainActivity.this, msg, Toast.LENGTH_SHORT).show();
                         }
                     });
         }
-        //       FirebaseMessaging.getInstance().getToken()
-//                .addOnCompleteListener(new OnCompleteListener<String>() {
-//                    @Override
-//                    public void onComplete(@NonNull Task<String> task) {
-//                        if (!task.isSuccessful()) {
-//                            Log.w(TAG, "Fetching FCM registration token failed", task.getException());
-//                            return;
-//                        }
-//
-//                        // Get new FCM registration token
-//                        String token = task.getResult();
-//                        SaveSharedPreferences.setFCMToken(MainActivity.this, token);
-//                        Log.i(TAG, "onComplete : " + SaveSharedPreferences.getFCMToken(MainActivity.this));
-//                        Log.i(TAG, token);
-//                    }
-//                });
     }
 
     @Override


### PR DESCRIPTION
`MainActivity.java`에서 onStart() 메소드 제거 및 주석을 삭제했습니다.
`MainActivity.java` 내 알림 구현을 위해 작성했던 코드 중 에러를 발생시키는 부분이 있어서 onStart() 메소드 제거함

[에러 내용]
`NewItemFragment.java`에서 갤러리 이미지 적용 후 복귀 시 이전 화면이 아닌 홈화면으로 복귀하는 문제가 있었음.

[원인]
갤러리 이미지 적용 후 복귀를 할 때 `MainActivity.java`(`NewItemFragment.java`가 소속됨)의 onStart()가 실행되면서 *flag값을 0(홈)으로 초기화하기 때문에 발생한 문제였음.
*flag : 각 프래그먼트전환을 위한 구분 플래그

[해결]
onStart()제거 및 onCreate()에서 초기 플래그 값 지정