### PR TITLE
Feature:#156

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -68,6 +68,15 @@ dependencies {
     implementation 'com.google.firebase:firebase-core:19.0.0'
     implementation 'androidx.work:work-runtime:2.7.0-alpha04'
 
+//    // @brief : 엑티비티와 프레그먼트간 데이터 전달에서 이벤트 버스 사용
+//    implementation 'com.squareup:otto:1.3.8'
+    implementation 'androidx.fragment:fragment:1.4.0-alpha06'
+
+    // @brief : 크롬(Chrome)브라우저를 이용한 디버깅 툴 (잠시 보류)
+//    implementation 'com.facebook.stetho:stetho:1.6.0'
+//    implementation 'com.facebook.stetho:stetho-js-rhino:1.6.0'
+//    implementation 'com.facebook.stetho:stetho-okhttp3:1.6.0'
+
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test.ext:junit:1.1.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
@@ -97,6 +106,10 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
 
     // @brief : ViewModel을 사용하기 위한 라이브러리 추가
-    def lifecycle_version = "1.1.1"
-    implementation "android.arch.lifecycle:extensions:$lifecycle_version"
+    //def lifecycle_version = "1.1.1"
+    def lifecycle_version = "2.2.0"
+    implementation "androidx.lifecycle:lifecycle-viewmodel:$lifecycle_version"
+    implementation "androidx.lifecycle:lifecycle-livedata:$lifecycle_version"
+    //implementation "android.arch.lifecycle:extensions:$lifecycle_version"
+    //implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,8 +34,6 @@
             android:name="com.google.firebase.messaging.default_notification_channel_id"
             android:value="@string/default_notification_channel_id" />
 
-        <activity android:name=".detail.FolderDetailActivity"></activity>
-        <activity android:name=".add.NewItemActivity" />
         <activity android:name=".IntroActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -43,6 +41,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".detail.FolderDetailActivity"></activity>
+        <activity android:name=".sign.SigninActivity" />
+        <activity android:name=".sign.SignupActivity" />
+        <activity android:name=".MainActivity" /> <!-- @ brief : kakao 로그인을 위해 Redirect URI 접근 -->
+        <activity android:name=".detail.ItemDetailActivity" />
         <activity
             android:name=".add.LinkSharingActivity"
             android:theme="@style/AppThemePopup">
@@ -52,17 +55,10 @@
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
-        <activity android:name=".sign.SigninActivity" />
-        <activity android:name=".sign.SignupActivity" />
-
-        <service
-            android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
-            android:enabled="true" />
-
-        <activity android:name=".detail.ItemDetailActivity" />
         <activity android:name=".cart.CartActivity" />
+        <activity android:name=".add.NewItemActivity" />
         <activity android:name=".folder.FolderListActivity" />
-        <activity android:name=".MainActivity" /> <!-- @ brief : kakao 로그인을 위해 Redirect URI 접근 -->
+        <activity android:name=".noti.NotiSettingActivity" />
         <activity android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
@@ -75,6 +71,7 @@
                     android:scheme="kakaoe5c80a93a90709e1f697d50166b62b30" />
             </intent-filter>
         </activity> <!-- @brief: 이미지의 캐시가 저장될 수 있는 경로를 지정 -->
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="com.hyeeyoung.wishboard"
@@ -84,6 +81,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/filepaths" />
         </provider>
+
+        <!-- @brief : AWS S3 service -->
+        <service
+            android:name="com.amazonaws.mobileconnectors.s3.transferutility.TransferService"
+            android:enabled="true" />
 
         <!-- @brief : FCM service -->
         <service android:name=".service.FireBaseMessagingService">

--- a/app/src/main/java/com/hyeeyoung/wishboard/add/NewItemFragment.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/add/NewItemFragment.java
@@ -1,12 +1,14 @@
 package com.hyeeyoung.wishboard.add;
 
 import android.Manifest;
+import android.app.Activity;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Environment;
 import android.provider.MediaStore;
+import android.text.TextUtils;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -15,33 +17,29 @@ import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
-
+import androidx.activity.result.ActivityResultLauncher;
+import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
-
 import com.hyeeyoung.wishboard.R;
-
 import com.hyeeyoung.wishboard.RealPathUtil;
 import com.hyeeyoung.wishboard.config.WindowPermission;
 import com.hyeeyoung.wishboard.folder.FolderListActivity;
-
+import com.hyeeyoung.wishboard.model.NotiItem;
 import com.hyeeyoung.wishboard.model.WishItem;
+import com.hyeeyoung.wishboard.noti.NotiSettingActivity;
 import com.hyeeyoung.wishboard.remote.IRemoteService;
 import com.hyeeyoung.wishboard.remote.ServiceGenerator;
 import com.hyeeyoung.wishboard.service.AwsS3Service;
-
 import java.io.File;
-
 import com.hyeeyoung.wishboard.service.SaveSharedPreferences;
-import com.squareup.picasso.Picasso;
-
+import com.hyeeyoung.wishboard.util.DateFormatUtil;
 import java.io.IOException;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
-
 import okhttp3.ResponseBody;
 import retrofit2.Call;
 import retrofit2.Callback;
@@ -59,7 +57,7 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
     // the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
     private static final String ARG_PARAM1 = "param1";
     private static final String ARG_PARAM2 = "param2";
-    private static final String TAG = "NewItemFragment";
+    private static final String TAG = "아이템 수동 등록";
 
     // TODO: Rename and change types of parameters
     private String mParam1;
@@ -100,14 +98,15 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
     // @param : 클릭 이벤트에서의 클릭 대상 View
     private ConstraintLayout item_image_layout;
     private LinearLayout btn_folder, btn_noti;
-    private ImageButton save;
     private ImageView item_image;
+    private TextView save, noti_type, noti_date;
     private EditText item_name, item_price, item_url, item_memo;
     public AwsS3Service aws_s3;
     private String time_stamp, image_path;
     private WishItem wish_item; //@brief : 서버연동 시 사용, 추가
-
-    // @ brief : 카메라, 갤러리 접근
+    private NotiItem noti_item;
+    private ImageButton add_photo_btn;
+    // @param : 카메라, 갤러리 접근
     private File file;
     private Uri img_uri, photo_uri, album_uri;
     private String current_photo_path;
@@ -115,12 +114,13 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
     private static final int FROM_ALBUM = 1;
     private LinearLayout layout;
     private String user_id = "";
+    private String type, date;
+//    private SharedItemVM viewModel;
 
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         view = inflater.inflate(R.layout.fragment_new_item, container, false);
-
         init();
 
         if (SaveSharedPreferences.getUserId(this.getActivity()).length() != 0)
@@ -130,24 +130,26 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
     }
 
     public void init(){
-        item_image_layout = (ConstraintLayout) view.findViewById(R.id.item_image_layout);
-        btn_folder = (LinearLayout) view.findViewById(R.id.btn_folder);
-        btn_noti = (LinearLayout) view.findViewById(R.id.btn_noti);
-        save = (ImageButton) view.findViewById(R.id.save);
+        item_image_layout = view.findViewById(R.id.item_image_layout);
+        btn_folder = view.findViewById(R.id.btn_folder);
+        btn_noti = view.findViewById(R.id.btn_noti);
+        save = view.findViewById(R.id.save);
+        item_name = view.findViewById(R.id.item_name);
+        item_price = view.findViewById(R.id.item_price);
+        item_url = view.findViewById(R.id.item_url);
+        noti_type = view.findViewById(R.id.noti_type);
+        noti_date = view.findViewById(R.id.noti_date);
+        item_memo = view.findViewById(R.id.item_memo);
+        item_image = view.findViewById(R.id.item_image);
+        layout = view.findViewById(R.id.layout);
+        add_photo_btn = view.findViewById(R.id.add_photo_btn);
 
         item_image_layout.setOnClickListener(this);
         btn_folder.setOnClickListener(this);
         btn_noti.setOnClickListener(this);
         save.setOnClickListener(this);
 
-        item_name = (EditText) view.findViewById(R.id.item_name);
-        item_price = (EditText) view.findViewById(R.id.item_price);
-        item_url = (EditText) view.findViewById(R.id.item_url);
-        item_memo = (EditText) view.findViewById(R.id.item_memo);
-        item_image = (ImageView) view.findViewById(R.id.item_image);
-        layout = (LinearLayout)view.findViewById(R.id.layout);
-
-        // @brief : TedPermission 라이브러리 -> 카메라 권한 획득
+        // @brief : TedPermission 라이브러리를 통해 카메라 권한 획득
         new WindowPermission(getContext()).setPermission(
                 Manifest.permission.WRITE_EXTERNAL_STORAGE, Manifest.permission.CAMERA
         );
@@ -159,9 +161,8 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
      */
     private WishItem getWishItem() {
         WishItem wish_item = new WishItem();
-
         wish_item.user_id = user_id;
-        wish_item.folder_id = "1"; // @TODO : 폴더 DB연동 후 변경하기
+        wish_item.setFolder_id(null);
 
         // @brief : 사용자가 입력한 아이템데이터 가져오기
         wish_item.item_name = item_name.getText().toString();
@@ -169,14 +170,13 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
         String get_item_url = item_url.getText().toString().replace(" ", ""); //@ @brief : 링크로 이동 시 공백에 의한 예외를 방지하기위해 공백 처리
         String get_item_memo = item_memo.getText().toString();
 
-        // @brief : 아이템 등록 시 파일명 중복 방지를 위해 파일명으로 등록 시간으로 지정, 추후 파일명도 추가할 예정
-        time_stamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
-        wish_item.item_image = IRemoteService.IMAGE_URL + time_stamp;
+        if(image_path != null && image_path.length() > 0){
+            // @brief : 아이템 등록 시 파일명 중복 방지를 위해 파일명으로 등록 시간으로 지정
+            time_stamp = new SimpleDateFormat("yyyyMMdd_HHmmss").format(new Date());
+            wish_item.item_image = IRemoteService.IMAGE_URL + time_stamp;
+        }
 
-        /**
-         * @brief : 아이템 가격, url, 메모에 대한 null값 예외처리
-         */
-
+        // @brief : 아이템 가격, url, 메모에 대한 null값 예외처리
         // @brief : 가격데이터 예외처리
         if (get_item_price.isEmpty()) {
             wish_item.setItem_price(null);
@@ -197,48 +197,32 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
         } else {
             wish_item.item_memo = get_item_memo;
         }
+
         return wish_item;
     }
 
     /**
      * @param : wish_item 사용자가 새로 입력한 아이템 객체
      * @return : 입력하지 않았다면 true, 입력했다면 false
-     * @brief :사용자가 상품명을 입력했는지를 확인
+     * @brief :사용자가 상품명과 이미지를 입력했는지를 확인
      */
-    private boolean isNoName(WishItem wish_item) {
-        if (wish_item.item_name.trim().isEmpty()) {
+    private boolean isNoData(WishItem wish_item) {
+        String name = wish_item.item_name.trim();
+        String img = wish_item.item_image;
+
+        if (name.isEmpty() && TextUtils.isEmpty(img)){
+            Toast.makeText(getContext(), "이미지와 상품명을 입력해주세요.", Toast.LENGTH_SHORT).show();
             return true;
-        } else {
-            return false;
+        } else if (name.isEmpty()){
+            Toast.makeText(getContext(), "상품명을 작성해주세요.", Toast.LENGTH_SHORT).show();
+            return true;
+        } else if (TextUtils.isEmpty(img)){
+            Toast.makeText(getContext(), "이미지를 업로드해주세요.", Toast.LENGTH_SHORT).show();
+            return true;
         }
+
+        return false;
     }
-
-    // @TODO : 유효한 url인지 체크, 추후 완성
-//    public boolean checkUrl(String url) {
-//        boolean check = false;
-//        try {
-//            URL tempUrl = new URL(url);
-//            HttpURLConnection connection = (HttpURLConnection) tempUrl.openConnection();
-//            connection.setRequestMethod("GET");
-//            connection.connect();
-//
-//            if (200 == connection.getResponseCode()) check = true;
-//        } catch (IOException e) {
-//            return false;
-//        }
-//        return check;
-//    }
-
-//    Handler handler = new Handler(){
-//        public void handleMessage(Message msg) {
-//            Bundle bundle = msg.getData();
-//            boolean is_valid_url = bundle.getBoolean("is_valid_url");
-//            if (!is_valid_url){
-//                Snackbar.make((LinearLayout)view.findViewById(R.id.layout), "존재하지 않는 url입니다.", Snackbar.LENGTH_SHORT).show();
-//                return;
-//            }
-//        }
-//    };
 
     /**
      * @brief : 사용자가 입력한 정보를 저장
@@ -247,75 +231,102 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
         wish_item = getWishItem();
 
         // @brief : 아이템 이름을 입력하지 않은 경우
-        if (isNoName(wish_item)) {
-            // @brief : 스낵바 띄우기
-            //new CustumSnackbar(getView(), "아이템 이름을 입력해주세요.", Snackbar.LENGTH_SHORT).show();
-            Toast.makeText(getContext(), "아이템 이름을 입력해주세요.", Toast.LENGTH_SHORT).show(); // @brief : 아이템 정보 입력을 요구
-
+        if (isNoData(wish_item)) {
+            //Toast.makeText(getContext(), "아이템 이름을 입력해주세요.", Toast.LENGTH_SHORT).show(); // @brief : 아이템 정보 입력을 요구
             return;
         }
 
-        // @TODO : 유효한 url인지 체크, 추후 완성
-//        new Thread(){
-//            public void run(){
-//                boolean is_valid_url = checkUrl(wish_item.getItem_url());
-//                Bundle bundle = new Bundle();
-//                bundle.putBoolean("is_valid_url", is_valid_url);
-//
-//                Message msg = handler.obtainMessage();
-//                msg.setData(bundle);
-//                handler.sendMessage(msg);
-//            }
-//        }.start();
 
+        else{
+            // @param : @ s3에 이미지 업로드를 위한 s3 객체
+            aws_s3 = new AwsS3Service(getActivity().getApplicationContext());
+            /**
+             * @brief : S3에 이미지 파일 업로드
+             * @param image_path : 이미지 파일 경로
+             * @param time_stamp : 이미지파일명 중복 방지를 위한 현재 시간 값을 추가해서 파일명 지정함
+             */
+            aws_s3.uploadFile(new File(image_path), time_stamp);
+            IRemoteService remote_service = ServiceGenerator.createService(IRemoteService.class);
+            Call<ResponseBody> call = remote_service.insertItemInfo(wish_item);
+            call.enqueue(new Callback<ResponseBody>() {
+                @Override
+                public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                    // @brief : 서버연결 성공한 경우
+                    if (response.isSuccessful()) {
+                        String seq = null;
+                        try {
+                            seq = response.body().string();
+                            if(!noti_type.equals(null)) {
+                                noti_item = new NotiItem(user_id, seq, type, date);
+                                noti_item.setToken(SaveSharedPreferences.getFCMToken(getContext()));
+                                addNoti();
+                            }
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                        Log.i(TAG, seq);
 
-//        if (!checkUrl(wish_item.getItem_url())) {
-//            //Snackbar.m
-//            Toast.makeText(getContext(), "존재하지 않는 url입니다.", Toast.LENGTH_SHORT).show(); // @brief : 아이템 정보 입력을 요구
-//            return;
-//        }
+                        // @brief : 디스플레이된 데이터 리셋
+                        item_image.setImageResource(0);
+                        item_name.setText("");
+                        item_price.setText("");
+                        item_url.setText("");
+                        item_memo.setText("");
+                        noti_type.setText("");
+                        noti_date.setText("");
 
-        // @param aws_s3 : @ s3에 이미지 업로드를 위한 s3 객체 생성
-        aws_s3 = new AwsS3Service(getActivity().getApplicationContext());
-        /**
-         * @brief : S3에 이미지 파일 업로드
-         * @param image_path : 이미지 파일 경로
-         * @param time_stamp : 이미지파일명 중복 방지를 위한 현재 시간 값을 추가해서 파일명 지정함
-         */
-        aws_s3.uploadFile(new File(image_path), time_stamp);
+                        // @brief : 저장 완료 후 사진 등록을 위한 플러스 버튼 보이도록 변경
+                        add_photo_btn.setVisibility(View.VISIBLE);
+
+                        //viewModel.setIsUpdated(true); // @brief : update 여부 true
+                        Toast.makeText(getContext(), "위시리스트에 추가했습니다.", Toast.LENGTH_SHORT).show(); // @brief : 아이템 정보 입력을 요구
+
+                    } else { // @brief : 통신에 실패한 경우
+                        Log.e(TAG, "Retrofit 통신 실패");
+                        //viewModel.setIsUpdated(false); // @brief : update 여부 false
+                    }
+                }
+
+                @Override
+                public void onFailure(Call<ResponseBody> call, Throwable t) {
+                    // @brief : 통식 실패 ()시 callback (예외 발생, 인터넷 끊김 등의 시스템적 이유로 실패)
+                    Log.e(TAG, "서버 연결 실패");
+                    // viewModel.setIsUpdated(false); // @brief : update여부 false
+                }
+            });
+        }
+    }
+
+    /**
+     * @brief : 사용자가 상품 알림을 설정한 경우 알림을 저장
+     */
+    private void addNoti(){
+        Log.i(TAG, "addNoti : " + noti_item);
         IRemoteService remote_service = ServiceGenerator.createService(IRemoteService.class);
-        Call<ResponseBody> call = remote_service.insertItemInfo(wish_item);
+        Call<ResponseBody> call = remote_service.insertItemNoti(noti_item);
+
         call.enqueue(new Callback<ResponseBody>() {
             @Override
             public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
-                // @brief : 서버연결 성공한 경우
                 if (response.isSuccessful()) {
+                    // @brief : 정상적으로 통신 성공한 경우
                     String seq = null;
                     try {
                         seq = response.body().string();
                     } catch (IOException e) {
                         e.printStackTrace();
                     }
-                    Log.e("아이템 등록", seq);
+                    Log.i(TAG, "알림 등록 성공 : " + seq);
 
-                    // @brief : 디스플레이된 데이터 리셋
-                    item_image.setImageResource(0);
-                    item_name.setText("");
-                    item_price.setText("");
-                    item_url.setText("");
-                    item_memo.setText("");
-
-                    Toast.makeText(getContext(), "위시리스트에 추가했습니다.", Toast.LENGTH_SHORT).show(); // @brief : 아이템 정보 입력을 요구
-
-                } else { // @brief : 통신에 실패한 경우
-                    Log.e("아이템 등록", "Retrofit 통신 실패");
+                } else {
+                    // @brief : 통신에 실패한 경우
+                    Log.e(TAG, "알림 등록 오류" + response.message());
                 }
             }
-
             @Override
             public void onFailure(Call<ResponseBody> call, Throwable t) {
                 // @brief : 통식 실패 ()시 callback (예외 발생, 인터넷 끊김 등의 시스템적 이유로 실패)
-                Log.e("아이템 등록", "서버 연결 실패");
+                Log.e(TAG, "서버 연결 실패" + t.getMessage());
             }
         });
     }
@@ -331,8 +342,10 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
                 Intent intent = new Intent(getActivity(), FolderListActivity.class);
                 startActivity(intent);
                 break;
+
             case R.id.btn_noti:
-                // @ brief : 추후 사용
+                Intent intent_noti = new Intent(getActivity(), NotiSettingActivity.class);
+                someActivityResultLauncher.launch(intent_noti);
                 break;
 
             case R.id.save:
@@ -340,6 +353,20 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
                 break;
         }
     }
+
+    // @brief : NotiSettingActivity에서 사용자가 입력한 알림 정보가 MainActivity를 거쳐서 이곳으로 전달 됨
+    ActivityResultLauncher<Intent> someActivityResultLauncher = registerForActivityResult(
+            new ActivityResultContracts.StartActivityForResult(),
+            result -> {
+                if (result.getResultCode() == Activity.RESULT_OK) {
+                    type = result.getData().getStringExtra("type");
+                    date = result.getData().getStringExtra("date");
+                    noti_type.setText(type);
+                    noti_date.setText(DateFormatUtil.shortDateMDHM(date));
+                    noti_type.setVisibility(View.VISIBLE);
+                    noti_date.setVisibility(View.VISIBLE);
+                }
+            });
 
     // @see : http://dailyddubby.blogspot.com/2018/04/107-tedpermission.html
     // @brief : 앨범 선택 클릭
@@ -458,6 +485,8 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
 
                         // @brief : 이미지뷰에 이미지 디스플레이
                         item_image.setImageURI(photo_uri);
+                        add_photo_btn.setVisibility(View.GONE);
+
                     } catch (Exception e) {
                         e.printStackTrace();
                         Log.v("알림", "앨범에서 가져오기 에러");
@@ -473,7 +502,7 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
                     galleryAddPic();
                     // @brief : 이미지뷰에 이미지셋팅
                     item_image.setImageURI(img_uri);
-
+                    add_photo_btn.setVisibility(View.GONE);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -508,6 +537,5 @@ public class NewItemFragment extends Fragment implements View.OnClickListener {
         Uri contentUri = Uri.fromFile(f);
         mediaScanIntent.setData(contentUri);
         getContext().sendBroadcast(mediaScanIntent);
-//        new CustumSnackbar(getView(), "사진이 저장되었습니다", Snackbar.LENGTH_SHORT).show();
     }
 }

--- a/app/src/main/java/com/hyeeyoung/wishboard/model/NotiItem.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/model/NotiItem.java
@@ -8,6 +8,13 @@ public class NotiItem {
     public NotiItem() {
     }
 
+    public NotiItem(String user_id, String item_id, String item_notification_type, String item_notification_date) {
+        this.user_id = user_id;
+        this.item_id = item_id;
+        this.item_notification_type = item_notification_type;
+        this.item_notification_date = item_notification_date;
+    }
+
     public String getUser_id() {
         return user_id;
     }

--- a/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiFragment.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiFragment.java
@@ -10,6 +10,7 @@ import androidx.fragment.app.Fragment;
 import androidx.recyclerview.widget.DividerItemDecoration;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 
 import com.hyeeyoung.wishboard.R;
 import com.hyeeyoung.wishboard.adapter.NotiAdapter;
@@ -26,7 +27,6 @@ import retrofit2.Call;
 import retrofit2.Callback;
 import retrofit2.Response;
 
-// -------------------- https://youngest-programming.tistory.com/76 ---------------------------=
 /**
  * A simple {@link Fragment} subclass.
  * Use the {@link NotiFragment#newInstance} factory method to
@@ -78,6 +78,7 @@ public class NotiFragment extends Fragment {
     RecyclerView recyclerView;
     NotiAdapter adapter;
     private LinearLayoutManager linearLayoutManager;
+    //private SwipeRefreshLayout swipeRefreshLayout;
 
     private String user_id = "";
     @Override
@@ -86,6 +87,7 @@ public class NotiFragment extends Fragment {
         view = inflater.inflate(R.layout.fragment_noti, container, false);
         if(SaveSharedPreferences.getUserId(this.getActivity()).length() != 0)
             user_id = SaveSharedPreferences.getUserId(this.getActivity());
+
         return view;
     }
 
@@ -117,6 +119,16 @@ public class NotiFragment extends Fragment {
         recyclerView.addItemDecoration(new DividerItemDecoration(getActivity(), DividerItemDecoration.VERTICAL));
         linearLayoutManager = new LinearLayoutManager(this.getActivity());
         recyclerView.setLayoutManager(linearLayoutManager);
+
+        // @TODO : 새로고침 적용 안 됨
+//        // @brief : 새로고침
+//        swipeRefreshLayout = view.findViewById(R.id.swipe_refresh);
+//        // @brief : 새로고침이 발생할 경우
+//        swipeRefreshLayout.setOnRefreshListener(() -> {
+//            selectNotiInfo(user_id); //swipe 시 서버 재조회
+//            Log.i(TAG, "refresh_update 발생");
+//            swipeRefreshLayout.setRefreshing(false); // @brief : update 종료 알림
+//        });
     }
 
     /**

--- a/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiSettingActivity.java
+++ b/app/src/main/java/com/hyeeyoung/wishboard/noti/NotiSettingActivity.java
@@ -1,0 +1,129 @@
+package com.hyeeyoung.wishboard.noti;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.Animation;
+import android.view.animation.Transformation;
+import android.widget.LinearLayout;
+import android.widget.Switch;
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import com.hyeeyoung.wishboard.R;
+import com.hyeeyoung.wishboard.util.NumberPickerUtil;
+
+public class NotiSettingActivity extends AppCompatActivity {
+    private static final String TAG = "알림설정";
+    private NumberPickerUtil np_util;
+    private String noti_date, noti_type;
+    private Switch switch_noti;
+
+    @Override
+    protected void onCreate(@NonNull Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_noti_setting);
+
+        noti_type = null;
+        noti_date = null;
+        np_util = new NumberPickerUtil();
+        init();
+
+        // @brief : 저장된 상태 데이터로 각 뷰에 내용 복구
+        if (savedInstanceState != null) {
+            np_util.type.setValue(savedInstanceState.getInt("type"));
+            np_util.date.setValue(savedInstanceState.getInt("date"));
+            np_util.hour.setValue(savedInstanceState.getInt("hour"));
+            np_util.minute.setValue(savedInstanceState.getInt("minute"));
+        }
+    }
+
+    // @brief : 화면 회전 시 상태 저장
+    @Override
+    public void onSaveInstanceState(@NonNull Bundle outState) {
+        super.onSaveInstanceState(outState);
+        outState.putInt("type", np_util.type.getValue());
+        outState.putInt("date", np_util.date.getValue());
+        outState.putInt("hour", np_util.hour.getValue());
+        outState.putInt("minute", np_util.minute.getValue());
+    }
+
+    private void init() {
+        switch_noti = findViewById(R.id.noti_switch);
+        LinearLayout noti_setting = findViewById(R.id.noti_setting);
+
+        // @brief : 알림 설정 토글 스위치 클릭 이벤트 처리
+        switch_noti.setOnCheckedChangeListener((compoundButton, isChecked) -> {
+            if (isChecked) {
+                noti_setting.setVisibility(View.VISIBLE);
+                expand(noti_setting);
+            } else {
+                noti_setting.setVisibility(View.GONE);
+                noti_type = null;
+                noti_date = null;
+            }
+        });
+
+        np_util.noti_types_array = getResources().getStringArray(R.array.noti_types_setting_array);
+        np_util.type = findViewById(R.id.num_picker_type);
+        np_util.date = findViewById(R.id.num_picker_date);
+        np_util.hour = findViewById(R.id.num_picker_hour);
+        np_util.minute = findViewById(R.id.num_picker_minute);
+        np_util.initNumperPicker();
+    }
+
+    public void onClick(View v) {
+        switch (v.getId()) {
+            // @brief : back 버튼 클릭 시 이전 화면으로 돌아가기
+            case R.id.back:
+                // @brief : 오른쪽 -> 왼쪽으로 화면 전환
+                onBackPressed();
+                overridePendingTransition(R.anim.slide_left_enter, R.anim.slide_left_exit);
+                break;
+
+            case R.id.save:
+
+                // @brief : 토글 버튼이 활성화된 상태인 경우 사용자가 설정한 알림 정보를 NewItemFragment로 전달
+                if (switch_noti.isChecked()) {
+                    noti_type = np_util.noti_types_array[np_util.type.getValue()];
+                    noti_date = np_util.dates_server[np_util.date.getValue()] + " " + np_util.hour.getValue() + ":" + np_util.minute.getValue() * 5 + ":00";
+                }
+                Intent intent = new Intent();
+                intent.putExtra("type", noti_type);
+                intent.putExtra("date", noti_date);
+                setResult(Activity.RESULT_OK, intent);
+                onBackPressed();
+                overridePendingTransition(R.anim.slide_left_enter, R.anim.slide_left_exit);
+                break;
+        }
+
+    }
+
+    // @brief : 알림 설정 레이아웃 펼치기 애니메이션 적용
+    private void expand(final View layout) {
+        layout.measure(View.MeasureSpec.UNSPECIFIED, View.MeasureSpec.UNSPECIFIED);
+        final int targetHeight = layout.getMeasuredHeight();
+
+        layout.getLayoutParams().height = 1;
+        Animation a = new Animation() {
+            @Override
+            protected void applyTransformation(float interpolatedTime, Transformation t) {
+                layout.getLayoutParams().height = interpolatedTime == 1
+                        ? ViewGroup.LayoutParams.WRAP_CONTENT
+                        : (int) (targetHeight * interpolatedTime);
+                layout.requestLayout();
+            }
+
+            @Override
+            public boolean willChangeBounds() {
+                return true;
+            }
+        };
+
+        a.setInterpolator(new AccelerateDecelerateInterpolator());
+        a.setDuration(200);
+        layout.startAnimation(a);
+    }
+}

--- a/app/src/main/res/drawable/custom_switch_background.xml
+++ b/app/src/main/res/drawable/custom_switch_background.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_checked="false">
+        <shape
+            android:shape="rectangle" >
+
+            <corners
+                android:radius="15dp" />
+
+            <size
+                android:width="30dp"
+                android:height="25dp" />
+
+            <solid
+                android:color="@color/mediumGray" />
+        </shape>
+    </item>
+    <item
+        android:state_checked="true">
+        <shape
+            android:shape="rectangle" >
+
+            <corners
+                android:radius="15dp" />
+
+            <size
+                android:width="30dp"
+                android:height="25dp" />
+
+            <solid
+                android:color="@color/green" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/drawable/custom_thumb.xml
+++ b/app/src/main/res/drawable/custom_thumb.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:state_checked="false">
+        <shape
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:shape="oval">
+
+            <size
+                android:width="25dp"
+                android:height="25dp" />
+
+            <solid
+                android:color="@color/white" />
+
+            <stroke
+                android:width="2dp"
+                android:color="@color/mediumGray" />
+
+        </shape>
+    </item>
+    <item
+        android:state_checked="true">
+        <shape
+            xmlns:android="http://schemas.android.com/apk/res/android"
+            android:shape="oval">
+
+        <size
+            android:width="25dp"
+            android:height="25dp" />
+
+        <solid
+            android:color="@color/white" />
+
+        <stroke
+            android:width="2dp"
+            android:color="@color/green" />
+        </shape>
+    </item>
+</selector>

--- a/app/src/main/res/layout/activity_noti_setting.xml
+++ b/app/src/main/res/layout/activity_noti_setting.xml
@@ -1,0 +1,181 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:orientation="vertical">
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="15dp">
+
+        <ImageButton
+            android:id="@+id/back"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:onClick="onClick"
+            android:src="@drawable/back" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerHorizontal="true"
+            android:fontFamily="@font/noto_sans_kr_bold"
+            android:text="상품 알림 설정"
+            android:textColor="@color/black"
+            android:textSize="20dp" />
+
+        <ImageButton
+            android:id="@+id/save"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_centerVertical="true"
+            android:background="@android:color/transparent"
+            android:onClick="onClick"
+            android:src="@drawable/save" />
+    </RelativeLayout>
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:background="@color/black" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="15dp"
+        android:orientation="vertical">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="15dp"
+            android:orientation="horizontal">
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:fontFamily="@font/nanum_square_eb"
+                android:paddingBottom="5dp"
+                android:text="알림 수신"
+                android:textColor="@color/black"
+                android:textSize="15dp" />
+
+            <Switch
+                android:id="@+id/noti_switch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:checked="true"
+                android:layout_gravity="center_vertical|right"
+                android:track="@drawable/custom_switch_background"
+                android:thumb="@drawable/custom_thumb"/>
+        </LinearLayout>
+        <LinearLayout
+            android:id="@+id/noti_setting"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:animateLayoutChanges="true"
+            android:orientation="vertical">
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:paddingBottom="5dp"
+                    android:text="알림 유형"
+                    android:textColor="@color/black"
+                    android:textSize="15dp" />
+
+                <LinearLayout
+                    android:id="@+id/noti_type"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:gravity="center_vertical">
+
+                    <NumberPicker
+                        android:id="@+id/num_picker_type"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="4"
+                        android:selectionDividerHeight="0dp"
+                        android:theme="@style/AppTheme.NumberPicker" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="15dp"
+                android:orientation="vertical">
+
+                <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/nanum_square_eb"
+                    android:text="알림 시간"
+                    android:textColor="@color/black"
+                    android:textSize="15dp" />
+
+                <LinearLayout
+                    android:id="@+id/noti_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="150dp"
+                    android:gravity="center_vertical">
+
+                    <NumberPicker
+                        android:id="@+id/num_picker_date"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="4"
+                        android:selectionDividerHeight="0dp"
+                        android:theme="@style/AppTheme.NumberPicker" />
+
+                    <TextView
+                        android:id="@+id/invisible_colon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:fontFamily="@font/nanum_square_eb"
+                        android:text=":"
+                        android:textSize="15dp"
+                        android:visibility="invisible" />
+
+                    <NumberPicker
+                        android:id="@+id/num_picker_hour"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:selectionDividerHeight="0dp"
+                        android:theme="@style/AppTheme.NumberPicker" />
+
+                    <TextView
+                        android:id="@+id/colon"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_vertical"
+                        android:fontFamily="@font/nanum_square_eb"
+                        android:text=":"
+                        android:textColor="@color/black"
+                        android:textSize="15dp" />
+
+                    <NumberPicker
+                        android:id="@+id/num_picker_minute"
+                        android:layout_width="0dp"
+                        android:layout_height="match_parent"
+                        android:layout_weight="1"
+                        android:selectionDividerHeight="0dp"
+                        android:theme="@style/AppTheme.NumberPicker" />
+                </LinearLayout>
+            </LinearLayout>
+        </LinearLayout>
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_noti.xml
+++ b/app/src/main/res/layout/fragment_noti.xml
@@ -2,8 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:background="@color/white">
+    android:background="@color/white"
+    android:orientation="vertical">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -23,8 +23,8 @@
             android:id="@+id/cart"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginRight="20dp"
             android:layout_centerVertical="true"
+            android:layout_marginRight="20dp"
             android:layout_toLeftOf="@id/more"
             android:background="@android:color/transparent"
             android:src="@drawable/cart" />
@@ -33,16 +33,16 @@
             android:id="@+id/cart_item_cnt"
             android:layout_width="wrap_content"
             android:layout_height="15dp"
-            android:layout_marginRight="10dp"
-            android:paddingHorizontal="5dp"
-            android:gravity="center"
             android:layout_alignTop="@id/title"
+            android:layout_marginRight="10dp"
             android:layout_toLeftOf="@id/more"
+            android:background="@drawable/background_cart_item_cnt"
             android:fontFamily="@font/noto_sans_kr_bold"
+            android:gravity="center"
+            android:paddingHorizontal="5dp"
             android:text="5"
             android:textColor="@color/black"
-            android:textSize="10dp"
-            android:background="@drawable/background_cart_item_cnt" />
+            android:textSize="10dp" />
 
         <ImageButton
             android:id="@+id/more"
@@ -53,56 +53,58 @@
             android:background="@android:color/transparent"
             android:src="@drawable/more" />
     </RelativeLayout>
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="15dp"
-                android:textAlignment="center"
-                android:textSize="13dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="지난 알림" />
 
-<!-- @brief : 클릭이벤트에 따라 <View>의 visibility 속성값 변경-->
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="@color/black"
-                android:visibility="visible"
-                />
-        </LinearLayout>
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:gravity="center"
-            android:orientation="vertical">
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginVertical="15dp"
-                android:textAlignment="center"
-                android:textSize="13dp"
-                android:textColor="@color/black"
-                android:fontFamily="@font/nanum_square_r"
-                android:text="캘린더 알림" />
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="2dp"
-                android:background="@color/black"
-                android:visibility="invisible"
-                />
-        </LinearLayout>
-    </LinearLayout>
+    <!-- @todo : 캘린더 알림 구현 예정 -->
+    <!--    <LinearLayout-->
+    <!--        android:layout_width="match_parent"-->
+    <!--        android:layout_height="wrap_content">-->
+    <!--        <LinearLayout-->
+    <!--            android:layout_width="0dp"-->
+    <!--            android:layout_height="wrap_content"-->
+    <!--            android:layout_weight="1"-->
+    <!--            android:gravity="center"-->
+    <!--            android:orientation="vertical">-->
+    <!--            <TextView-->
+    <!--                android:layout_width="wrap_content"-->
+    <!--                android:layout_height="wrap_content"-->
+    <!--                android:layout_marginVertical="15dp"-->
+    <!--                android:textAlignment="center"-->
+    <!--                android:textSize="13dp"-->
+    <!--                android:textColor="@color/black"-->
+    <!--                android:fontFamily="@font/nanum_square_r"-->
+    <!--                android:text="지난 알림" />-->
+
+    <!--&lt;!&ndash; @brief : 클릭이벤트에 따라 <View>의 visibility 속성값 변경&ndash;&gt;-->
+    <!--            <View-->
+    <!--                android:layout_width="match_parent"-->
+    <!--                android:layout_height="2dp"-->
+    <!--                android:background="@color/black"-->
+    <!--                android:visibility="visible"-->
+    <!--                />-->
+    <!--        </LinearLayout>-->
+    <!--        <LinearLayout-->
+    <!--            android:layout_width="0dp"-->
+    <!--            android:layout_height="wrap_content"-->
+    <!--            android:layout_weight="1"-->
+    <!--            android:gravity="center"-->
+    <!--            android:orientation="vertical">-->
+    <!--            <TextView-->
+    <!--                android:layout_width="wrap_content"-->
+    <!--                android:layout_height="wrap_content"-->
+    <!--                android:layout_marginVertical="15dp"-->
+    <!--                android:textAlignment="center"-->
+    <!--                android:textSize="13dp"-->
+    <!--                android:textColor="@color/black"-->
+    <!--                android:fontFamily="@font/nanum_square_r"-->
+    <!--                android:text="캘린더 알림" />-->
+    <!--            <View-->
+    <!--                android:layout_width="match_parent"-->
+    <!--                android:layout_height="2dp"-->
+    <!--                android:background="@color/black"-->
+    <!--                android:visibility="invisible"-->
+    <!--                />-->
+    <!--        </LinearLayout>-->
+    <!--    </LinearLayout>-->
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/recyclerview_noti_list"
@@ -113,4 +115,18 @@
         android:scrollbarThumbVertical="@android:color/darker_gray"
         android:scrollbars="vertical"/>
 
+    <!-- @brief : 밑으로 당겨서 refresh -->
+<!--    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout-->
+<!--        android:layout_width="match_parent"-->
+<!--        android:layout_height="match_parent"-->
+<!--        android:id="@+id/swipe_refresh">-->
+<!--        <androidx.recyclerview.widget.RecyclerView-->
+<!--            android:id="@+id/recyclerview_noti_list"-->
+<!--            android:layout_width="match_parent"-->
+<!--            android:layout_height="match_parent"-->
+<!--            android:scrollbarFadeDuration="0"-->
+<!--            android:scrollbarSize="5dp"-->
+<!--            android:scrollbarThumbVertical="@android:color/darker_gray"-->
+<!--            android:scrollbars="vertical"/>-->
+<!--    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>-->
 </LinearLayout>


### PR DESCRIPTION
1. `build.gradle`
- ViewModelProviders 클래스 Deprecated됨
- 이것의 대체 방안인 ViewModelProvider(s없음)을 사용하기 위해 새 모듈 추가함
- [참고 사이트](https://readystory.tistory.com/176)
- 로그 출력하지 않고 크롬 브라우저로 데이터 값을 출력할 수 있는 간편한 디버깅 모듈을 추가 (추후 사용 예정)

2. `AndroidManifest.xml`
- NotiSettingActivity.java`추가
- 각 엑티비티의 위치를 쉽게 파악할 수 있도록 <activity>순서(화면 이동 순) 조정

3. `NewItemActivity.java`
- 상품알림정보(type, date) TextView 디스플레이
- `NotiSettingActivity.java` 연결했으나 알림설정 버튼 클릭 시 터치 이벤트 누락 에러 발생(해결 중)
```
Touch event's action is 0x0 (deviceType=0)
```

4. ` NewItemFragment.java`
-  `NotiSettingActivity.java` 연결
- 상품알림정보(type, date) TextView 디스플레이
- 상품명, 이미지 입력하지 않은 경우 예외처리
- 갤러리 이미지가 ImageView에 적용된 경우 +버튼 안보이도록 수정

5. `HomeFragment.java` 
- swipeRefreshLayout 사용해서 새로고침 적용

6. `NotiItem.java`
- user_id, item_id, item_notification_type, item_notification_date를 파라미터로 갖는 생성자 추가

7. `NotiFragment.java`
- `NotiFragment.java`에도 새로고침 적용해봤는데 3번과 동일한 터치이벤트 누락 에러 발생(해결 중)

8. `NotiSettingActivity.java`
- _`NewItemFragment.java`와 'NewItemActivity.java'_(파일명 변경 예정)에서 상품 알림 설정 시 이동하게 될 엑티비티 추가
- 스위치 on/off에 따른 클릭이벤트 처리 (알림 설정 레이아웃 펼치기 애니메이션 적용)
- 사용자가 설정한 내용을 저장할 경우 _엑티비티_로 데이터 전달

9. `custom_switch_background.xml`, `custom_thumb.xml`
- 스위치 버튼 커스텀

10. `activity_noti_setting.xml`
- 알림 설정 레이아웃(`NotiSettingActivity.java`의 레이아웃) 추가

11. `fragment_noti.xml`
- 지난알림, 캘린더 알림 주석 처리(배포 후 구현)
- SwipeRefreshLayout 추가했으나 주석처리 함(7번 참고)